### PR TITLE
fix: preserve smart-list flags when creating tasks

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -46,6 +46,8 @@ export async function addTodo(formData: FormData) {
   const title = formData.get("title");
   const listId = formData.get("listId") as string | null;
   const isMyDay = formData.get("isMyDay") === "true";
+  const isImportant = formData.get("isImportant") === "true";
+  const planned = formData.get("planned") === "true";
 
   if (!title || typeof title !== "string" || title.trim().length === 0) {
     return;
@@ -56,6 +58,8 @@ export async function addTodo(formData: FormData) {
       title: title.trim(),
       listId: listId || null,
       isMyDay,
+      isImportant,
+      dueDate: planned ? new Date() : null,
     },
   });
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -119,6 +119,8 @@ export function AppShell({ todos, lists }: AppShellProps) {
           <TodoInput
             listId={!isSmartList ? activeView : undefined}
             isMyDay={activeView === "myday"}
+            isImportant={activeView === "important"}
+            planned={activeView === "planned"}
             placeholder={
               activeView === "myday"
                 ? "What will you focus on today?"

--- a/src/components/TodoInput.tsx
+++ b/src/components/TodoInput.tsx
@@ -7,12 +7,16 @@ import { Plus } from "lucide-react";
 interface TodoInputProps {
   listId?: string;
   isMyDay?: boolean;
+  isImportant?: boolean;
+  planned?: boolean;
   placeholder?: string;
 }
 
 export function TodoInput({
   listId,
   isMyDay,
+  isImportant,
+  planned,
   placeholder = "Add a task...",
 }: TodoInputProps) {
   const formRef = useRef<HTMLFormElement>(null);
@@ -53,6 +57,10 @@ export function TodoInput({
         {isMyDay ? (
           <input type="hidden" name="isMyDay" value="true" />
         ) : null}
+        {isImportant ? (
+          <input type="hidden" name="isImportant" value="true" />
+        ) : null}
+        {planned ? <input type="hidden" name="planned" value="true" /> : null}
       </div>
     </form>
   );


### PR DESCRIPTION
This pull request adds support for marking todos as "important" and "planned" throughout the application. The changes ensure that these new attributes are passed from the UI to the backend, and that planned todos receive a due date.

New todo attributes and backend integration:

* Added `isImportant` and `planned` fields to the `TodoInput` component and its props, and ensured they are sent as hidden fields in the todo creation form. (`src/components/TodoInput.tsx`) [[1]](diffhunk://#diff-a4c0abdf9c3af54978e30661b3f07ea32a3f8ebc015ed52c0bf92699cea13fbdR10-R19) [[2]](diffhunk://#diff-a4c0abdf9c3af54978e30661b3f07ea32a3f8ebc015ed52c0bf92699cea13fbdR60-R63)
* Updated the `AppShell` component to pass `isImportant` and `planned` props to `TodoInput` based on the current view (e.g., "important", "planned"). (`src/components/AppShell.tsx`)
* Modified the `addTodo` action to read `isImportant` and `planned` from the form data and set these fields on the new todo. If `planned` is set, the todo receives a `dueDate`. (`src/actions/todos.ts`) [[1]](diffhunk://#diff-0b043b89d644801560b403ae2430f0ea873f473af52eaa69760225da4ddb66c7R49-R50) [[2]](diffhunk://#diff-0b043b89d644801560b403ae2430f0ea873f473af52eaa69760225da4ddb66c7R61-R62)