### PR TITLE
fix: enforce launch save errors and harden launch IPC boundaries

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -16,6 +16,28 @@ const isDev = process.env.NODE_ENV === "development";
 const DEFAULT_PORT = 3000;
 let serverPort = DEFAULT_PORT;
 
+function isAllowedExternalUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function isTrustedSender(event) {
+  const frameUrl = event?.senderFrame?.url;
+  if (!frameUrl || typeof frameUrl !== "string") {
+    return false;
+  }
+
+  if (isDev) {
+    return frameUrl.startsWith("http://127.0.0.1:3000") || frameUrl.startsWith("http://localhost:3000");
+  }
+
+  return frameUrl.startsWith(`http://127.0.0.1:${serverPort}`);
+}
+
 function isPlainObject(value) {
   if (!value || typeof value !== "object") {
     return false;
@@ -73,6 +95,10 @@ function getPickerWindow(event) {
 }
 
 ipcMain.handle("launchpad:pick-file", async (event) => {
+  if (!isTrustedSender(event)) {
+    return buildPickerUnavailableResult("untrusted-sender");
+  }
+
   try {
     const result = await dialog.showOpenDialog(getPickerWindow(event), {
       properties: ["openFile"],
@@ -95,6 +121,10 @@ ipcMain.handle("launchpad:pick-file", async (event) => {
 });
 
 ipcMain.handle("launchpad:pick-app", async (event) => {
+  if (!isTrustedSender(event)) {
+    return buildPickerUnavailableResult("untrusted-sender");
+  }
+
   try {
     const result = await dialog.showOpenDialog(getPickerWindow(event), {
       properties: ["openFile"],
@@ -117,7 +147,11 @@ ipcMain.handle("launchpad:pick-app", async (event) => {
   }
 });
 
-ipcMain.handle("launchpad:launch-all", async (_event, payload) => {
+ipcMain.handle("launchpad:launch-all", async (event, payload) => {
+  if (!isTrustedSender(event)) {
+    return buildInvalidLaunchPayloadResult();
+  }
+
   const resources = normalizeLaunchResourcesPayload(payload);
   if (resources === null) {
     return buildInvalidLaunchPayloadResult();
@@ -234,8 +268,22 @@ function createWindow() {
 
   // Open external links in default browser
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    if (isAllowedExternalUrl(url)) {
+      shell.openExternal(url);
+    }
     return { action: "deny" };
+  });
+
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    const trustedOrigin = `http://127.0.0.1:${serverPort}`;
+    const trustedDevOrigins = ["http://localhost:3000", "http://127.0.0.1:3000"];
+    if (
+      url === trustedOrigin ||
+      (isDev && trustedDevOrigins.some((origin) => url.startsWith(origin)))
+    ) {
+      return;
+    }
+    event.preventDefault();
   });
 
   mainWindow.on("closed", () => {

--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/db";
 import {
   parseLaunchResources,
   serializeLaunchResources,
+  trySerializeLaunchResources,
   validateLaunchResource,
   type LaunchResource,
 } from "@/lib/launchResources";
@@ -183,7 +184,17 @@ export async function updateTodo(
     listId?: string | null;
     launchResources?: LaunchResource[] | string | null;
   }
-) {
+ ): Promise<
+  | { ok: true }
+  | {
+      ok: false;
+      error:
+        | "invalid_launch_resource"
+        | "launch_resources_too_large"
+        | "todo_not_found"
+        | "unknown";
+    }
+> {
   const updateData: Record<string, unknown> = {};
   if (data.title !== undefined) updateData.title = data.title;
   if (data.notes !== undefined) updateData.notes = data.notes;
@@ -207,24 +218,40 @@ export async function updateTodo(
     if (data.launchResources === null) {
       updateData.launchResources = "[]";
     } else if (typeof data.launchResources === "string") {
-      updateData.launchResources = serializeLaunchResources(
+      const serialized = trySerializeLaunchResources(
         parseLaunchResources(data.launchResources)
       );
+      if (!serialized.ok) {
+        return { ok: false, error: "launch_resources_too_large" };
+      }
+      updateData.launchResources = serialized.value;
     } else {
       const normalized: LaunchResource[] = [];
       for (const item of data.launchResources) {
         const result = validateLaunchResource(item);
         if (!result.ok) {
-          return;
+          return { ok: false, error: "invalid_launch_resource" };
         }
         normalized.push(result.value);
       }
-      updateData.launchResources = serializeLaunchResources(normalized);
+      const serialized = trySerializeLaunchResources(normalized);
+      if (!serialized.ok) {
+        return { ok: false, error: "launch_resources_too_large" };
+      }
+      updateData.launchResources = serialized.value;
     }
   }
 
-  await prisma.todo.update({ where: { id }, data: updateData });
-  revalidatePath("/");
+  try {
+    await prisma.todo.update({ where: { id }, data: updateData });
+    revalidatePath("/");
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("Record to update not found")) {
+      return { ok: false, error: "todo_not_found" };
+    }
+    return { ok: false, error: "unknown" };
+  }
 }
 
 export async function deleteTodo(id: string) {

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -25,7 +25,7 @@ import {
 import { cn } from "@/lib/cn";
 import {
   parseLaunchResources,
-  serializeLaunchResources,
+  trySerializeLaunchResources,
   validateLaunchResource,
   type LaunchResource,
 } from "@/lib/launchResources";
@@ -168,7 +168,18 @@ export function TaskDetail({ todo, onClose }: TaskDetailProps) {
     }
 
     startSavingLaunchResources(async () => {
-      await updateTodo(todo.id, { launchResources: normalized });
+      const result = await updateTodo(todo.id, { launchResources: normalized });
+      if (!result.ok) {
+        if (result.error === "launch_resources_too_large") {
+          setLaunchValidationError("Launch resources are too large. Shorten labels/values.");
+        } else if (result.error === "invalid_launch_resource") {
+          setLaunchValidationError("Fix invalid resource values before saving.");
+        } else {
+          setLaunchValidationError("Could not save launch resources. Please retry.");
+        }
+        return;
+      }
+
       setLaunchResources(normalized);
       setLaunchSummary(
         normalized.length === 0
@@ -182,7 +193,13 @@ export function TaskDetail({ todo, onClose }: TaskDetailProps) {
     setLaunchSummary(null);
     setLaunchValidationError(null);
 
-    const serialized = serializeLaunchResources(launchResources);
+    const serializedResult = trySerializeLaunchResources(launchResources);
+    if (!serializedResult.ok) {
+      setLaunchValidationError("Launch resources are too large. Shorten labels/values.");
+      return;
+    }
+
+    const serialized = serializedResult.value;
 
     startLaunchingResources(async () => {
       const result = await launchAllClient(serialized);

--- a/src/lib/launchResources.test.ts
+++ b/src/lib/launchResources.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   parseLaunchResources,
   serializeLaunchResources,
+  trySerializeLaunchResources,
   validateLaunchResource,
 } from "./launchResources.ts";
 
@@ -81,4 +82,27 @@ test("serializes and re-parses valid resources", () => {
 
   assert.equal(parsed.length, 1);
   assert.equal(parsed[0]?.type, "app");
+});
+
+test("returns explicit error when serialized payload exceeds limit", () => {
+  const veryLongValue = `https://example.com/${"a".repeat(5000)}`;
+  const items = Array.from({ length: 12 }, (_, index) => {
+    const result = validateLaunchResource({
+      type: "url",
+      label: `Very Long Link ${index + 1}`,
+      value: veryLongValue,
+    });
+
+    if (!result.ok) {
+      throw new Error("Failed to construct valid launch resource for overflow test");
+    }
+
+    return result.value;
+  });
+
+  const serializationResult = trySerializeLaunchResources(items);
+  assert.equal(serializationResult.ok, false);
+  if (!serializationResult.ok) {
+    assert.equal(serializationResult.error, "payload_too_large");
+  }
 });

--- a/src/lib/launchResources.ts
+++ b/src/lib/launchResources.ts
@@ -8,6 +8,10 @@ export type LaunchResource = {
   createdAt: string;
 };
 
+export type LaunchResourceSerializationResult =
+  | { ok: true; value: string }
+  | { ok: false; error: "payload_too_large" };
+
 const MAX_RESOURCES = 12;
 const MAX_PAYLOAD_LENGTH = 16_000;
 const ALLOWED_DEEP_LINK_PROTOCOLS = new Set([
@@ -185,6 +189,13 @@ export function parseLaunchResources(raw: string | null | undefined): LaunchReso
 }
 
 export function serializeLaunchResources(items: LaunchResource[]): string {
+  const result = trySerializeLaunchResources(items);
+  return result.ok ? result.value : JSON.stringify([]);
+}
+
+export function trySerializeLaunchResources(
+  items: LaunchResource[]
+): LaunchResourceSerializationResult {
   const sanitized: LaunchResource[] = [];
 
   for (const item of items) {
@@ -200,8 +211,8 @@ export function serializeLaunchResources(items: LaunchResource[]): string {
 
   const serialized = JSON.stringify(sanitized);
   if (serialized.length > MAX_PAYLOAD_LENGTH) {
-    return JSON.stringify([]);
+    return { ok: false, error: "payload_too_large" };
   }
 
-  return serialized;
+  return { ok: true, value: serialized };
 }


### PR DESCRIPTION
This pull request introduces important security improvements for Electron IPC handlers and enhances launch resource serialization error handling throughout the app. It adds sender validation to IPC endpoints, restricts navigation and external links, and ensures that launch resource payloads exceeding size limits are handled gracefully with clear user feedback.

**Security improvements in Electron main process:**

* Added `isTrustedSender` and `isAllowedExternalUrl` helper functions to validate IPC sender origins and allowed external URLs (`electron/main.js`).
* Updated IPC handlers (`launchpad:pick-file`, `launchpad:pick-app`, `launchpad:launch-all`) to reject untrusted senders, preventing unauthorized access to sensitive actions (`electron/main.js`). [[1]](diffhunk://#diff-d26babf4803ac63f9da8f41503879776892f456b3d9c4fcb184610527aca0531R98-R101) [[2]](diffhunk://#diff-d26babf4803ac63f9da8f41503879776892f456b3d9c4fcb184610527aca0531R124-R127) [[3]](diffhunk://#diff-d26babf4803ac63f9da8f41503879776892f456b3d9c4fcb184610527aca0531L120-R154)
* Restricted navigation and external link handling to only allow trusted origins and URLs, preventing navigation hijacking (`electron/main.js`).

**Launch resource serialization and error handling:**

* Introduced `trySerializeLaunchResources`, returning explicit errors if the payload is too large, and updated all relevant code to use it instead of silent truncation (`src/lib/launchResources.ts`, [[1]](diffhunk://#diff-eb63fe9da554b42215a14d58d5d921b2cca1c0c072500fcf1925f4904db35d20R11-R14) [[2]](diffhunk://#diff-eb63fe9da554b42215a14d58d5d921b2cca1c0c072500fcf1925f4904db35d20R192-R198) [[3]](diffhunk://#diff-eb63fe9da554b42215a14d58d5d921b2cca1c0c072500fcf1925f4904db35d20L203-R217); `src/actions/todos.ts`, [[4]](diffhunk://#diff-0b043b89d644801560b403ae2430f0ea873f473af52eaa69760225da4ddb66c7R7) [[5]](diffhunk://#diff-0b043b89d644801560b403ae2430f0ea873f473af52eaa69760225da4ddb66c7L210-R254); `src/components/TaskDetail.tsx`, [[6]](diffhunk://#diff-9b4a327bcb56296c61e2f7e83c0738a17c2ccee0f24d4a3d03d45b4f7d0d899cL28-R28) [[7]](diffhunk://#diff-9b4a327bcb56296c61e2f7e83c0738a17c2ccee0f24d4a3d03d45b4f7d0d899cL185-R202).
* Updated `updateTodo` and `TaskDetail` to provide user-facing error messages when launch resources are invalid or too large, improving UX and robustness (`src/actions/todos.ts`, [[1]](diffhunk://#diff-0b043b89d644801560b403ae2430f0ea873f473af52eaa69760225da4ddb66c7L186-R197) [[2]](diffhunk://#diff-0b043b89d644801560b403ae2430f0ea873f473af52eaa69760225da4ddb66c7L210-R254); `src/components/TaskDetail.tsx`, [[3]](diffhunk://#diff-9b4a327bcb56296c61e2f7e83c0738a17c2ccee0f24d4a3d03d45b4f7d0d899cL171-R182) [[4]](diffhunk://#diff-9b4a327bcb56296c61e2f7e83c0738a17c2ccee0f24d4a3d03d45b4f7d0d899cL185-R202).

**Testing:**

* Added a unit test to verify that serialization fails with an explicit error when the launch resource payload exceeds the allowed size (`src/lib/launchResources.test.ts`, [src/lib/launchResources.test.tsR86-R108](diffhunk://#diff-99b86f546521979f728a131f8b51cdd9f8fb8f1268efff7030ba51830931f2aeR86-R108)).

These changes collectively harden the application against IPC misuse and data overflows, while providing clearer error handling and feedback to users and developers.