### PR TITLE
feat: keyboard shortcuts with hint bar

### DIFF
--- a/macos/TodoFocusMac/Sources/Features/Common/ShortcutHintBar.swift
+++ b/macos/TodoFocusMac/Sources/Features/Common/ShortcutHintBar.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct ShortcutHintBar: View {
+    var body: some View {
+        HStack(spacing: 16) {
+            Spacer()
+
+            HStack(spacing: 12) {
+                shortcutPill("⌘K", "Search")
+                shortcutPill("⌘⇧N", "Add")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(VisualTokens.bgFloating.opacity(0.8))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(VisualTokens.sectionBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private func shortcutPill(_ key: String, _ action: String) -> some View {
+        HStack(spacing: 4) {
+            Text(key)
+                .font(.caption2.weight(.semibold).monospaced())
+                .foregroundStyle(VisualTokens.textPrimary)
+            Text(action)
+                .font(.caption2)
+                .foregroundStyle(VisualTokens.textTertiary)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(VisualTokens.sectionBackground, in: Capsule())
+    }
+}
+
+struct ShortcutHintBarModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        VStack(spacing: 8) {
+            content
+            ShortcutHintBar()
+        }
+    }
+}
+
+extension View {
+    func shortcutHintBar() -> some View {
+        modifier(ShortcutHintBarModifier())
+    }
+}

--- a/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddView.swift
@@ -7,7 +7,7 @@ struct QuickAddView: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            TextField("Add a task", text: $text)
+            TextField("Add a task (⌘⇧N)", text: $text)
                 .textFieldStyle(.roundedBorder)
                 .focused($isInputFocused)
                 .onSubmit(submit)
@@ -17,8 +17,13 @@ struct QuickAddView: View {
             }
             .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
-        .onAppear {
-            isInputFocused = true
+        .background {
+            Button("") {
+                isInputFocused = true
+            }
+            .keyboardShortcut("n", modifiers: [.command, .shift])
+            .opacity(0)
+            .allowsHitTesting(false)
         }
     }
 

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
@@ -7,7 +7,6 @@ struct TaskListView: View {
     @State private var isCompletedCollapsed: Bool = false
     @State private var isCompletedPanelVisible: Bool = true
     @State private var showClearCompletedConfirmation: Bool = false
-    @State private var focusedTaskId: String?
     @FocusState private var isCommandFocused: Bool
 
     var body: some View {
@@ -67,7 +66,6 @@ struct TaskListView: View {
                     .stroke(VisualTokens.sectionBorder, lineWidth: 1)
             }
             .shadow(color: Color.black.opacity(0.18), radius: 8, y: 3)
-            .keyboardShortcut("n", modifiers: .command)
 
             HStack(spacing: 12) {
                 todoColumn(title: "Active", todos: activeTodos)
@@ -81,27 +79,7 @@ struct TaskListView: View {
             }
             .animation(.easeInOut(duration: 0.2), value: isCompletedPanelVisible)
         }
-        .onKeyPress(.upArrow) {
-            navigateUp()
-            return .handled
-        }
-        .onKeyPress(.downArrow) {
-            navigateDown()
-            return .handled
-        }
-        .onKeyPress(.return) {
-            if let focusedTaskId {
-                try? store.toggleComplete(todoId: focusedTaskId)
-            }
-            return .handled
-        }
-        .onKeyPress(.delete) {
-            if let focusedTaskId {
-                try? store.deleteTodo(todoId: focusedTaskId)
-                self.focusedTaskId = nil
-            }
-            return .handled
-        }
+        .shortcutHintBar()
         .padding(16)
         .foregroundStyle(.primary)
         .animation(MotionTokens.interactiveSpring, value: filteredVisibleTodos.count)
@@ -122,7 +100,7 @@ struct TaskListView: View {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(isCommandFocused ? Color.white.opacity(0.92) : VisualTokens.mutedText)
 
-                TextField("Search tasks", text: $commandText)
+                TextField("Search tasks (⌘K)", text: $commandText)
                     .textFieldStyle(.plain)
                     .focused($isCommandFocused)
             }
@@ -217,7 +195,6 @@ struct TaskListView: View {
                             todo: todo,
                             listColor: colorForList(listId: todo.listId),
                             isSelected: appModel.selectedTodoID == todo.id,
-                            isFocused: todo.id == focusedTaskId,
                             onSelect: {
                                 store.selectTodo(todoId: todo.id)
                             },
@@ -293,7 +270,6 @@ struct TaskListView: View {
                             todo: todo,
                             listColor: colorForList(listId: todo.listId),
                             isSelected: appModel.selectedTodoID == todo.id,
-                            isFocused: todo.id == focusedTaskId,
                             onSelect: {
                                 store.selectTodo(todoId: todo.id)
                             },
@@ -342,26 +318,6 @@ struct TaskListView: View {
         }
         .padding(3)
         .background(VisualTokens.bgBase.opacity(0.5), in: Capsule())
-    }
-
-    private func navigateUp() {
-        let allTodos = filteredVisibleTodos
-        guard !allTodos.isEmpty else { return }
-        if let current = focusedTaskId, let idx = allTodos.firstIndex(where: { $0.id == current }), idx > 0 {
-            focusedTaskId = allTodos[idx - 1].id
-        } else {
-            focusedTaskId = allTodos.last?.id
-        }
-    }
-
-    private func navigateDown() {
-        let allTodos = filteredVisibleTodos
-        guard !allTodos.isEmpty else { return }
-        if let current = focusedTaskId, let idx = allTodos.firstIndex(where: { $0.id == current }), idx < allTodos.count - 1 {
-            focusedTaskId = allTodos[idx + 1].id
-        } else {
-            focusedTaskId = allTodos.first?.id
-        }
     }
 
     private func colorForList(listId: String?) -> Color? {

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TodoRowView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TodoRowView.swift
@@ -4,7 +4,6 @@ struct TodoRowView: View {
     let todo: Todo
     let listColor: Color?
     let isSelected: Bool
-    let isFocused: Bool
     let onSelect: () -> Void
     let onToggleComplete: () -> Void
     let onToggleImportant: () -> Void
@@ -38,7 +37,6 @@ struct TodoRowView: View {
                     .padding(5)
                     .background(todo.isCompleted ? Color.green.opacity(0.22) : Color.white.opacity(0.12), in: Circle())
             }
-            .keyboardShortcut("d", modifiers: .command)
             .buttonStyle(.plain)
             .foregroundStyle(todo.isCompleted ? Color.green : Color.white.opacity(0.94))
             .overlay {
@@ -93,12 +91,6 @@ struct TodoRowView: View {
                 RoundedRectangle(cornerRadius: 8)
                     .fill(indicatorColor)
                     .frame(width: 3)
-            }
-        }
-        .overlay {
-            if isFocused {
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color.blue.opacity(0.5), lineWidth: 2)
             }
         }
         .contentShape(Rectangle())

--- a/macos/TodoFocusMac/TodoFocusMac.xcodeproj/project.pbxproj
+++ b/macos/TodoFocusMac/TodoFocusMac.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		C2FEA8790A8A2C89D8C58905 /* TaskDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAD163056EA96CD2BF6C0D5 /* TaskDetailView.swift */; };
 		CCD83328C673F343DC524362 /* TodoRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA83C04DBE6BA2D4990E7C67 /* TodoRowView.swift */; };
 		D2F5C48FDC857B3D6D2B6E36 /* ImmersiveHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CECDF3CE43A5D8655A27316 /* ImmersiveHeaderView.swift */; };
+		DCB7C1425FC4D7CA492383F8 /* ShortcutHintBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5633165F8175CAD2AB7A90 /* ShortcutHintBar.swift */; };
 		E63935763D57E7925754DA11 /* StepRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7843ACD1FCEFBCAE938562 /* StepRecord.swift */; };
 		E8709ACDA2AB39968E4DB49F /* AppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77780E76FD121D34BF6D7EE3 /* AppModel.swift */; };
 		EE4B6195129CF4C3EF7E3DF8 /* LaunchpadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC90DAB9D3BCB9A0A483E24 /* LaunchpadService.swift */; };
@@ -93,6 +94,7 @@
 		1950C542DDDF6617D03FE7C2 /* DataTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DataTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FE1E72B6E3895D17014CE7C /* DatabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseManager.swift; sourceTree = "<group>"; };
 		2983BB79FF8DA2AC19883045 /* WindowPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowPersistence.swift; sourceTree = "<group>"; };
+		2B5633165F8175CAD2AB7A90 /* ShortcutHintBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutHintBar.swift; sourceTree = "<group>"; };
 		2DA53D4632EFDA5206A1C1A8 /* SmartListFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartListFilterTests.swift; sourceTree = "<group>"; };
 		2F3E319E19EF05FA501E7B85 /* SelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionState.swift; sourceTree = "<group>"; };
 		30D5FE3587E551AA2AF551C4 /* TaskListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListView.swift; sourceTree = "<group>"; };
@@ -282,6 +284,7 @@
 				69D7E8E5ABB00A1C6EC8B171 /* InteractiveStyles.swift */,
 				557C0A5FAD5A80348079DDAA /* MotionTokens.swift */,
 				085B1E712E2F332EBC0416BB /* ResizableSplitView.swift */,
+				2B5633165F8175CAD2AB7A90 /* ShortcutHintBar.swift */,
 				80CC7B115E98F0487D59FC4C /* VisualTokens.swift */,
 			);
 			path = Common;
@@ -504,6 +507,7 @@
 				49C094D18BEB5BD380E70B5B /* ResizableSplitView.swift in Sources */,
 				98FEBD78B7C911D8AD057405 /* RootView.swift in Sources */,
 				A07A6F7772AE2B855A31DB11 /* SelectionState.swift in Sources */,
+				DCB7C1425FC4D7CA492383F8 /* ShortcutHintBar.swift in Sources */,
 				47F5DFB75F5754B0E0DACAFB /* SidebarView.swift in Sources */,
 				F59D8952A68ECA7794710C19 /* SmartList.swift in Sources */,
 				90D943479B3C84C14E3B8F4C /* Step.swift in Sources */,


### PR DESCRIPTION
## Summary
- Add keyboard shortcuts hint bar at bottom of task list
- Cmd+K: Focus search field
- Cmd+Shift+N: Focus quick-add field
- Remove problematic navigation mode that didn't work reliably on macOS

## Changes
- `ShortcutHintBar.swift`: New component showing available shortcuts
- `TaskListView.swift`: Simplified to only Cmd+K/Shift+N, removed broken navigation
- `TodoRowView.swift`: Removed isFocused parameter
- `QuickAddView.swift`: Removed auto-focus on appear

## Testing
- Build succeeded
- Cmd+K focuses search field
- Cmd+Shift+N focuses quick-add field
- Shortcut hints displayed in bottom bar