### PR TITLE
fix(deep-focus): bind ⌘⇧F keyboard shortcut to start deep focus

### DIFF
--- a/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
@@ -182,6 +182,7 @@ struct TaskDetailView: View {
                     .background(VisualTokens.accentTerracotta, in: Capsule())
                 }
                 .buttonStyle(.plain)
+                .keyboardShortcut("f", modifiers: [.command, .shift])
 
                 Button {
                     commitTitle(todoId: todo.id)


### PR DESCRIPTION
## Summary

- Fixes ⌘⇧F shortcut that was displayed in UI but had no binding
- Binds `.keyboardShortcut("f", modifiers: [.command, .shift])` to the Deep Focus button in TaskDetailView
- Shortcut now works when a task is selected and detail panel is visible

## Root Cause

The `ShortcutHintBar` displayed `⌘⇧F` as a hint pill, but no `.keyboardShortcut()` modifier was ever applied to any view to handle it. The `startDeepFocus(blockedApps:focusTaskId:)` method existed in `TodoAppStore` but had no trigger.

## Test Plan

- [x] Verify ⌘⇧F opens the Deep Focus setup sheet when a task is selected
- [x] Verify ⌘⇧F does nothing when no task is selected (detail panel not visible)
- [x] Verify clicking the Deep Focus button still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)