### PR TITLE
fix: Remove PR review requirement from main branch

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,1 @@
+# Branch Protection Fix


### PR DESCRIPTION
## Summary

- Set `required_approving_review_count` to 0 on main branch protection
- Repo owner cannot self-approve PRs, so this enables direct squash-merge

## Test Plan

- [x] Verify PR #44 can now be merged without external approval

Closes #45