### PR TITLE
fix: reset timeFilter when switching away from Overdue view

### DIFF
--- a/macos/TodoFocusMac/Sources/App/AppModel.swift
+++ b/macos/TodoFocusMac/Sources/App/AppModel.swift
@@ -17,6 +17,8 @@ final class AppModel {
             selectedTodoID = nil
             if next == .overdue {
                 timeFilter = .overdue
+            } else {
+                timeFilter = .allDates
             }
         }
     }


### PR DESCRIPTION
## Summary

- Fix bug where completing an overdue task caused all tasks to disappear
- Root cause: `timeFilter` was set to `.overdue` when selecting Overdue sidebar, but never reset when switching to other views
- Fix: In `selectSidebar`, set `timeFilter = .allDates` when `next != .overdue`

## Bug Description

1. User selects Overdue sidebar → `timeFilter = .overdue`
2. User completes an overdue task → task marked complete, `reload()` called
3. If user was on All Tasks/My Day/etc. OR switched views, `timeFilter` was still `.overdue`
4. With `timeFilter = .overdue`, the completed task is filtered out (`!isCompleted = false`)
5. Since `timeFilter` persisted, ALL tasks were filtered as overdue → empty list
6. Sidebar counts correct (use `todos` directly, not `visibleTodos`)
7. Restart "fixed" it (app defaults `timeFilter = .allDates` on launch)

## Test Plan

- [ ] Complete overdue task in Overdue view → task removed, other tasks still visible
- [ ] Complete overdue task in All Tasks view → task marked complete, view shows correctly
- [ ] Switch from Overdue to My Day → time filter resets, all My Day tasks visible
- [ ] Use filter picker in Overdue view, then switch views → filter resets

Closes #45