### PR TITLE
Fix stale Hard Focus lock after app relaunch

### DIFF
--- a/macos/TodoFocusMac/Sources/App/HardFocusSessionManager.swift
+++ b/macos/TodoFocusMac/Sources/App/HardFocusSessionManager.swift
@@ -36,12 +36,24 @@ final class HardFocusSessionManager: ObservableObject {
         self.agentPollInterval = agentPollInterval
         // Restore active session from persisted state after app relaunch/crash
         if let active = try? repository.activeSession() {
-            self.currentSession = active
-            self.isEnforcing = true
             // Reschedule timer from the persisted plannedEndTime (original duration may have partially elapsed)
             let remaining = active.plannedEndTime.timeIntervalSinceNow
-            if remaining > 0 {
-                startTimer(duration: remaining)
+            if active.plannedEndTime == .distantFuture || remaining > 0 {
+                self.currentSession = active
+                self.isEnforcing = true
+                if remaining > 0 {
+                    startTimer(duration: remaining)
+                }
+            } else {
+                // Timed session already expired while app was not running.
+                // Close it immediately so startup doesn't get stuck in a stale lock state.
+                try? repository.updateStatus(
+                    sessionId: active.sessionId,
+                    status: .completed,
+                    actualEndTime: Date()
+                )
+                self.currentSession = nil
+                self.isEnforcing = false
             }
         }
     }

--- a/macos/TodoFocusMac/Tests/CoreTests/HardFocusSessionManagerTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/HardFocusSessionManagerTests.swift
@@ -3,6 +3,37 @@ import XCTest
 
 @MainActor
 final class HardFocusSessionManagerTests: XCTestCase {
+    func testInitEndsExpiredTimedSession() throws {
+        let dbManager = try DatabaseManager(databasePath: ":memory:")
+        let repository = HardFocusSessionRepository(dbQueue: dbManager.dbQueue)
+        let session = HardFocusSessionRecord(
+            sessionId: "expired-session",
+            mode: "hard",
+            status: .active,
+            startTime: Date().addingTimeInterval(-600),
+            plannedEndTime: Date().addingTimeInterval(-60),
+            actualEndTime: nil,
+            unlockPhraseHash: "hash",
+            blockedApps: #"["com.apple.Safari"]"#,
+            focusTaskId: "task-1",
+            graceSeconds: 300,
+            createdAt: Date().addingTimeInterval(-600)
+        )
+        try repository.create(session)
+
+        let manager = HardFocusSessionManager(
+            repository: repository,
+            agentManager: MockHardFocusAgentManager(isRegistered: true, isRunning: true),
+            isAccessibilityTrusted: { true },
+            agentStartupTimeout: 0,
+            agentPollInterval: 0.01
+        )
+
+        XCTAssertFalse(manager.isEnforcing)
+        XCTAssertNil(manager.currentSession)
+        XCTAssertNil(try repository.activeSession())
+    }
+
     func testStartSessionRegistersAgentWhenNotRegistered() async throws {
         let dbManager = try DatabaseManager(databasePath: ":memory:")
         let repository = HardFocusSessionRepository(dbQueue: dbManager.dbQueue)


### PR DESCRIPTION
## 🛠️ Fix: Stale Hard Focus Lock On App Launch

### 🐞 Problem
If the app restarts after a timed Hard Focus session has already expired, startup restore logic still marks that session as active/enforcing.

Result:
- Unlock UI appears immediately on first app launch
- Entering Deep Focus fails to start because an "active" Hard Focus session appears to exist

### ✅ Root Cause
`HardFocusSessionManager.init` restored any `active` session from DB without validating whether `plannedEndTime` had already passed.

### ✅ Changes
- In startup restore:
  - If session is indefinite (`.distantFuture`) or still has remaining time: restore as before
  - If timed session already expired: mark it `.completed` immediately and do not enforce
- Added regression test for init with an expired active session

### 📁 Files
- `macos/TodoFocusMac/Sources/App/HardFocusSessionManager.swift`
- `macos/TodoFocusMac/Tests/CoreTests/HardFocusSessionManagerTests.swift`

### 🧪 Verification
- ✅ `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`

### 🎯 Impact
- Removes false lock screen on app startup
- Restores ability to start new Deep Focus sessions after stale timed session data
