### PR TITLE
fix: Hard Focus fallback enforcement when LaunchAgent is unavailable

### DIFF
--- a/macos/TodoFocusMac/Sources/App/HardFocusInProcessEnforcer.swift
+++ b/macos/TodoFocusMac/Sources/App/HardFocusInProcessEnforcer.swift
@@ -1,0 +1,77 @@
+import Foundation
+import AppKit
+
+@MainActor
+protocol HardFocusInProcessEnforcing {
+    func start(blockedApps: [String])
+    func stop()
+}
+
+@MainActor
+final class HardFocusInProcessEnforcer: HardFocusInProcessEnforcing {
+    private var launchObserver: NSObjectProtocol?
+    private var activationObserver: NSObjectProtocol?
+    private var blockedApps: Set<String> = []
+
+    func start(blockedApps: [String]) {
+        self.blockedApps = Set(blockedApps)
+
+        // Initial sweep: terminate already-running blocked apps.
+        for app in NSWorkspace.shared.runningApplications {
+            guard let bundleId = app.bundleIdentifier,
+                  self.blockedApps.contains(bundleId),
+                  bundleId != Bundle.main.bundleIdentifier else { continue }
+            terminate(app)
+        }
+
+        let center = NSWorkspace.shared.notificationCenter
+
+        launchObserver = center.addObserver(
+            forName: NSWorkspace.didLaunchApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
+            Task { @MainActor [weak self] in
+                self?.handle(app: app)
+            }
+        }
+
+        activationObserver = center.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
+            Task { @MainActor [weak self] in
+                self?.handle(app: app)
+            }
+        }
+    }
+
+    func stop() {
+        if let launchObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(launchObserver)
+            self.launchObserver = nil
+        }
+        if let activationObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(activationObserver)
+            self.activationObserver = nil
+        }
+        blockedApps = []
+    }
+
+    private func handle(app: NSRunningApplication) {
+        guard let bundleId = app.bundleIdentifier,
+              bundleId != Bundle.main.bundleIdentifier,
+              blockedApps.contains(bundleId) else { return }
+        terminate(app)
+    }
+
+    private func terminate(_ app: NSRunningApplication) {
+        let terminated = app.terminate()
+        if !terminated {
+            app.forceTerminate()
+        }
+    }
+}

--- a/macos/TodoFocusMac/Sources/App/HardFocusSessionManager.swift
+++ b/macos/TodoFocusMac/Sources/App/HardFocusSessionManager.swift
@@ -17,6 +17,7 @@ final class HardFocusSessionManager: ObservableObject {
 
     private let repository: HardFocusSessionRepository
     private let agentManager: HardFocusAgentControlling
+    private let inProcessEnforcer: HardFocusInProcessEnforcing
     private let isAccessibilityTrusted: () -> Bool
     private let agentStartupTimeout: TimeInterval
     private let agentPollInterval: TimeInterval
@@ -25,12 +26,14 @@ final class HardFocusSessionManager: ObservableObject {
     init(
         repository: HardFocusSessionRepository,
         agentManager: HardFocusAgentControlling = HardFocusAgentManager(),
+        inProcessEnforcer: HardFocusInProcessEnforcing = HardFocusInProcessEnforcer(),
         isAccessibilityTrusted: @escaping () -> Bool = { AXIsProcessTrusted() },
         agentStartupTimeout: TimeInterval = 2.0,
         agentPollInterval: TimeInterval = 0.1
     ) {
         self.repository = repository
         self.agentManager = agentManager
+        self.inProcessEnforcer = inProcessEnforcer
         self.isAccessibilityTrusted = isAccessibilityTrusted
         self.agentStartupTimeout = agentStartupTimeout
         self.agentPollInterval = agentPollInterval
@@ -41,6 +44,7 @@ final class HardFocusSessionManager: ObservableObject {
             if active.plannedEndTime == .distantFuture || remaining > 0 {
                 self.currentSession = active
                 self.isEnforcing = true
+                self.inProcessEnforcer.start(blockedApps: active.blockedAppsBundleIds)
                 if remaining > 0 {
                     startTimer(duration: remaining)
                 }
@@ -74,7 +78,9 @@ final class HardFocusSessionManager: ObservableObject {
             throw HardFocusError.accessibilityPermissionDenied
         }
 
-        try await ensureAgentIsRunning()
+        // Best-effort: register and wait for LaunchAgent, but don't fail session start
+        // when unavailable. In-process enforcer keeps hard focus functional while app runs.
+        _ = try? await ensureAgentIsRunning()
 
         // Prevent creating a second active session if one is already running
         if (try? repository.activeSession()) != nil {
@@ -112,6 +118,7 @@ final class HardFocusSessionManager: ObservableObject {
         try repository.create(session)
         currentSession = session
         isEnforcing = true
+        inProcessEnforcer.start(blockedApps: blockedApps)
 
         // Notify agent to start enforcing immediately (agent polls as fallback)
         DistributedNotificationCenter.default().postNotificationName(
@@ -152,6 +159,7 @@ final class HardFocusSessionManager: ObservableObject {
         currentSession = nil
         isEnforcing = false
         timer?.invalidate()
+        inProcessEnforcer.stop()
     }
 
     // MARK: - Private
@@ -190,6 +198,7 @@ final class HardFocusSessionManager: ObservableObject {
         currentSession = nil
         isEnforcing = false
         timer?.invalidate()
+        inProcessEnforcer.stop()
     }
 
     private func startTimer(duration: TimeInterval) {

--- a/macos/TodoFocusMac/Tests/CoreTests/HardFocusSessionManagerTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/HardFocusSessionManagerTests.swift
@@ -58,33 +58,31 @@ final class HardFocusSessionManagerTests: XCTestCase {
         XCTAssertNotNil(try repository.activeSession())
     }
 
-    func testStartSessionFailsWhenAgentIsNotRunning() async throws {
+    func testStartSessionSucceedsWhenAgentIsNotRunning() async throws {
         let dbManager = try DatabaseManager(databasePath: ":memory:")
         let repository = HardFocusSessionRepository(dbQueue: dbManager.dbQueue)
         let agent = MockHardFocusAgentManager(isRegistered: false, isRunning: false)
+        let enforcer = MockHardFocusInProcessEnforcer()
         let manager = HardFocusSessionManager(
             repository: repository,
             agentManager: agent,
+            inProcessEnforcer: enforcer,
             isAccessibilityTrusted: { true },
             agentStartupTimeout: 0,
             agentPollInterval: 0.01
         )
 
-        do {
-            try await manager.startSession(
-                blockedApps: ["com.apple.Safari"],
-                duration: 60,
-                focusTaskId: "task-1",
-                passphrase: "unlock"
-            )
-            XCTFail("Expected agentNotAvailable")
-        } catch let error as HardFocusError {
-            XCTAssertEqual(error, .agentNotAvailable)
-        }
+        try await manager.startSession(
+            blockedApps: ["com.apple.Safari"],
+            duration: 60,
+            focusTaskId: "task-1",
+            passphrase: "unlock"
+        )
 
         XCTAssertEqual(agent.registerCallCount, 1)
-        XCTAssertFalse(manager.isEnforcing)
-        XCTAssertNil(try repository.activeSession())
+        XCTAssertTrue(manager.isEnforcing)
+        XCTAssertNotNil(try repository.activeSession())
+        XCTAssertEqual(enforcer.lastStartedBlockedApps, ["com.apple.Safari"])
     }
 
     func testStartSessionWaitsForAgentToBecomeRunningAfterRegister() async throws {
@@ -141,5 +139,21 @@ private final class MockHardFocusAgentManager: HardFocusAgentControlling {
         registerCallCount += 1
         isRegistered = true
         registerTime = Date()
+    }
+}
+
+@MainActor
+private final class MockHardFocusInProcessEnforcer: HardFocusInProcessEnforcing {
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
+    private(set) var lastStartedBlockedApps: [String] = []
+
+    func start(blockedApps: [String]) {
+        startCallCount += 1
+        lastStartedBlockedApps = blockedApps
+    }
+
+    func stop() {
+        stopCallCount += 1
     }
 }

--- a/macos/TodoFocusMac/TodoFocusMac.xcodeproj/project.pbxproj
+++ b/macos/TodoFocusMac/TodoFocusMac.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		562F4C2B29D889F78C31AF57 /* Migrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D618BA5F04EE273ECD9EF530 /* Migrations.swift */; };
 		569BFB21A2090DBB610FFA38 /* AgentSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075FF7F688EDFDD0DA2CF732 /* AgentSessionController.swift */; };
 		5BD3BD4EDF2656D17AF51BE4 /* AgentHeartbeatRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FFFD681515D79596102C48 /* AgentHeartbeatRecord.swift */; };
+		5FD60125EFC0965590F89843 /* HardFocusInProcessEnforcer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C5CA8CF25F37C0C4358BE53 /* HardFocusInProcessEnforcer.swift */; };
 		617054A787911D3600EC4DF7 /* StepRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B875EF0C5AEEACBC449D970 /* StepRecord.swift */; };
 		639E4502F5B1767422B7A161 /* AppModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81F49BBBD3470E39E67D6825 /* AppModelTests.swift */; };
 		64CAC0EE2BA2F5B20FAEB504 /* SmartListFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA53D4632EFDA5206A1C1A8 /* SmartListFilterTests.swift */; };
@@ -158,6 +159,7 @@
 		173B7FBF596FE48369C865FF /* CoreTodo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreTodo.swift; sourceTree = "<group>"; };
 		19458B7C988B347EA18FCFF7 /* ExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportService.swift; sourceTree = "<group>"; };
 		1950C542DDDF6617D03FE7C2 /* DataTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DataTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1C5CA8CF25F37C0C4358BE53 /* HardFocusInProcessEnforcer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardFocusInProcessEnforcer.swift; sourceTree = "<group>"; };
 		2504E4980F2F0A6C58014D11 /* DeepFocusReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepFocusReportView.swift; sourceTree = "<group>"; };
 		27FFFD681515D79596102C48 /* AgentHeartbeatRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHeartbeatRecord.swift; sourceTree = "<group>"; };
 		2983BB79FF8DA2AC19883045 /* WindowPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowPersistence.swift; sourceTree = "<group>"; };
@@ -455,6 +457,7 @@
 				D97B7432D8B38188F373B1AF /* DeepFocusService.swift */,
 				6F213B8DC45CE5527CE01193 /* DeepFocusTimerNotifier.swift */,
 				034819C4AD6863939B8A97A4 /* HardFocusAgentManager.swift */,
+				1C5CA8CF25F37C0C4358BE53 /* HardFocusInProcessEnforcer.swift */,
 				C4C02F3CCE23A226FC531579 /* HardFocusSessionManager.swift */,
 				ABC90DAB9D3BCB9A0A483E24 /* LaunchpadService.swift */,
 				729482FCE1EC68FFAD05F576 /* QuickCaptureService.swift */,
@@ -747,6 +750,7 @@
 				D47CCAA280BB56FC203BAE6E /* ExportModels.swift in Sources */,
 				4CA6ED27D39773B7F998AE1D /* ExportService.swift in Sources */,
 				05A4E94740B3822DF32846A2 /* HardFocusAgentManager.swift in Sources */,
+				5FD60125EFC0965590F89843 /* HardFocusInProcessEnforcer.swift in Sources */,
 				C873786B788F91F014E6F313 /* HardFocusLockView.swift in Sources */,
 				8D1AF5857D6856A06AB31926 /* HardFocusSessionManager.swift in Sources */,
 				D8985E1616C869686A73FCC9 /* HardFocusSessionRecord.swift in Sources */,


### PR DESCRIPTION
## 🚑 Problem
On some installs (especially release-installed app with LaunchAgent not ready/unavailable), tapping **Start Deep Focus** looked like it did nothing.

## ✅ Root Cause
- `HardFocusSessionManager.startSession` failed hard when agent was unavailable.
- Upstream caller path could swallow the failure, so the user saw no effective start.

## 🛠️ What changed
- Added `HardFocusInProcessEnforcer` to enforce blocked apps directly in app process via `NSWorkspace` launch/activate notifications.
- Changed session start flow to:
  - attempt agent readiness as best-effort,
  - still start session and activate in-process enforcement when agent is unavailable.
- On app launch restore of active session, in-process enforcer is also started.
- On session end/emergency end, in-process enforcer is stopped.
- Updated `HardFocusSessionManagerTests` to cover fallback behavior.

## 🔒 Why this is safer
- Hard Focus no longer depends on a single external agent path.
- If LaunchAgent is healthy, existing behavior remains.
- If LaunchAgent is down, blocking still works.

## 🧪 Verification
- ✅ Release build passed:
  - `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
- ⚠️ Full test suite currently has pre-existing `CoreTests` compile issues on `main` (Swift 6 actor-isolation and older test API signatures), unrelated to this PR’s touched logic.

## 📂 Files changed
- `macos/TodoFocusMac/Sources/App/HardFocusInProcessEnforcer.swift`
- `macos/TodoFocusMac/Sources/App/HardFocusSessionManager.swift`
- `macos/TodoFocusMac/Tests/CoreTests/HardFocusSessionManagerTests.swift`
- `macos/TodoFocusMac/TodoFocusMac.xcodeproj/project.pbxproj`

## 🎯 User impact
Start Deep Focus now succeeds and enforces blocking even when agent bootstrap is flaky/unavailable on first run.
