### PR TITLE
docs(readme): refresh project messaging and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,51 @@
 # TodoFocus
 
 <p align="center">
-  <img src="assets/overdue-screenshot.png" alt="TodoFocus" width="800"/>
+  <img src="assets/overdue-screenshot.png" alt="TodoFocus" width="900"/>
 </p>
 
 <p align="center">
   <img src="https://img.shields.io/badge/macOS-14%2B-blue" alt="macOS 14+"/>
   <img src="https://img.shields.io/badge/SwiftUI-orange" alt="SwiftUI"/>
-  <img src="https://img.shields.io/badge/Database-SQLite-yellow" alt="SQLite"/>
-  <img src="https://img.shields.io/badge/License-AGPL--3.0-green" alt="AGPL-3.0"/>
+  <img src="https://img.shields.io/badge/Local--First-SQLite-yellow" alt="Local-first SQLite"/>
+  <img src="https://img.shields.io/github/v/release/michaelmjhhhh/TodoFocus" alt="Latest Release"/>
+  <img src="https://img.shields.io/github/license/michaelmjhhhh/TodoFocus" alt="License"/>
 </p>
 
----
+A local-first native macOS task app built for focused execution.
 
-Local-first native macOS todo app for **focused execution**, not just list keeping.
+TodoFocus is designed for people who want to stay in flow: pick a task, launch context, block distractions, and finish.
 
----
+## Why It Exists
 
-## Why TodoFocus
+Most todo apps are good at storing tasks but weak at helping you execute.
 
-| | |
-|---|---|
-| 💾 **Local-First** | Data lives on your machine in SQLite. No account, no cloud, no sync friction. |
-| ⚡ **Launch Everything** | Attach URLs, files, and apps to any task. Click **Launch All** to open your entire context at once. |
-| 🎯 **Smart Filters** | See exactly what matters today. Filter by Overdue, Today, Tomorrow, Next 7 days, or No date. |
-| 🔥 **Deep Focus** | Track focus time, block distracting apps, and set a timer to auto-end sessions. |
-| ⌨️ **Quick Capture** | Press **⌘⇧T** from anywhere to capture thoughts instantly. |
+TodoFocus prioritizes execution speed:
+- Start a focus session directly from a task
+- Launch all related resources with one click
+- Keep everything local and fast (no account, no sync setup)
 
----
+## Core Features
+
+- `Deep Focus`: timed or infinite focus sessions with blocked apps and session stats
+- `Hard Focus`: stricter lock mode for stronger distraction control
+- `Quick Capture` (`⌘⇧T`): capture ideas globally while working in other apps
+- `Context Launchpad`: attach URL/file/app resources to any task and launch all
+- `Per-view filtering`: overdue, today, tomorrow, next 7 days, no date
+- `Search` (`⌘K`): find tasks by title and notes
+- `My Day`: daily intent list for high-priority execution
 
 ## Quick Start
 
-```bash
-# Download latest release
-# → https://github.com/michaelmjhhhh/TodoFocus/releases
+### Option 1: Use Release Build (recommended)
 
-# Or build from source
+1. Open Releases: <https://github.com/michaelmjhhhh/TodoFocus/releases>
+2. Download latest `TodoFocus-macos-universal.zip`
+3. Unzip and move `TodoFocusMac.app` to Applications
+
+### Option 2: Build From Source
+
+```bash
 brew install xcodegen
 git clone https://github.com/michaelmjhhhh/TodoFocus.git
 cd TodoFocus/macos/TodoFocusMac
@@ -43,119 +53,49 @@ xcodegen generate
 xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
 ```
 
-**First launch:** Grant **Accessibility permission** when prompted (System Settings → Privacy & Security → Accessibility).
-
----
-
-## Features
-
-### 📋 Task Management
-| | |
-|---|---|
-| **Smart Lists** | My Day, Important, Planned — filter automatically |
-| **Custom Lists** | Create lists with 10 color options |
-| **Subtasks** | Break tasks into smaller pieces |
-| **Due Dates** | Relative display — "Today", "Tomorrow", "Overdue" |
-| **Notes** | Per-task free-text notes with auto-save |
-| **Search** | Press **⌘K** to search across all tasks |
-
-### 🎯 Focus
-| | |
-|---|---|
-| **Deep Focus Sessions** | Start a focus session on any task; tracks time and blocks distracting apps |
-| **Deep Focus Timer** | Set custom duration (25/45/60/90 min or custom) or Infinite mode. Timer auto-ends session, shows notification, marks task complete |
-
-### 🚀 Productivity
-| | |
-|---|---|
-| **Context Launchpad** | Attach URLs, files, and apps to a task; launch all in one click |
-| **Quick Capture** | Press **⌘⇧T** from any app to capture thoughts |
-| **Collapsible Completed** | Hide completed tasks to focus on active work |
-
-### 🎨 Customization
-| | |
-|---|---|
-| **Dark / Light Theme** | Toggle with sidebar button, ⌘⇧L, or Settings; dark by default |
-| **Resizable Panel** | Drag to adjust detail panel width |
-
----
+First launch may require Accessibility permission for global quick capture:
+`System Settings -> Privacy & Security -> Accessibility`
 
 ## Keyboard Shortcuts
 
 | Shortcut | Action |
-|----------|--------|
-| <kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd> | Quick Capture (global hotkey) |
-| <kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd> | Start Deep Focus on selected task |
-| <kbd>⌘</kbd><kbd>⇧</kbd><kbd>L</kbd> | Toggle theme (Dark → Light → System) |
-| <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd> | Add new task to current view |
-| <kbd>⌘</kbd><kbd>K</kbd> | Search tasks |
-| <kbd>⌘</kbd><kbd>W</kbd> | Close current window |
-| <kbd>⌘</kbd><kbd>Q</kbd> | Quit app |
+|---|---|
+| `⌘⇧T` | Quick Capture (global hotkey) |
+| `⌘⇧F` | Start Deep Focus on selected task |
+| `⌘⇧N` | Add new task |
+| `⌘K` | Search tasks |
 
----
+## Data and Privacy
 
-## Tech Stack
+- Local-first by default
+- SQLite database path: `~/Library/Application Support/todofocus/todofocus.db`
+- Import/Export supports backup-safe replace and merge workflows
 
-| Layer | Technology |
-|-------|------------|
-| UI Framework | SwiftUI |
-| State Management | Observation (`@Observable`) |
-| Database | SQLite via GRDB |
-| Build System | Xcode + xcodegen |
-| Packaging | Zipped `.app` in GitHub Releases |
+## Project Status
 
-### Project Structure
+Actively maintained.
 
-```
-macos/TodoFocusMac/
-├── Sources/
-│   ├── App/           # AppModel, TodoAppStore, DeepFocusService
-│   ├── Core/          # Domain models (Todo, List, Step)
-│   ├── Data/          # GRDB migrations, DTOs, repositories
-│   └── Features/      # SwiftUI views
-└── Tests/
-```
+If you test it and something feels off, open an issue with:
+- what you did
+- what you expected
+- what actually happened
+- your macOS version
 
-### Building
+Issue tracker: <https://github.com/michaelmjhhhh/TodoFocus/issues>
 
-```bash
-# Generate project after file changes
-xcodegen generate
+## Roadmap (Short Term)
 
-# Build
-xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
-
-# Test
-xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
-```
-
-### Releasing
-
-```bash
-git tag vX.Y.Z
-git push origin vX.Y.Z
-gh workflow run release-macos-native -f tag=vX.Y.Z
-```
-
----
-
-## Troubleshooting
-
-| Issue | Solution |
-|-------|----------|
-| Build fails after renaming files | Run `xcodegen generate` |
-| Data looks stale | Delete `~/Library/Application Support/todofocus/todofocus.db` |
-| Global hotkey doesn't work | Grant **Accessibility permission** in System Settings |
-| App launch fails | Grant **Full Disk Access** or relevant permissions |
-
----
+- Improve import/export UX and reliability
+- Continue hard-focus/deep-focus edge-case hardening
+- Polish onboarding and first-run clarity
 
 ## Contributing
 
-Issues and pull requests welcome.
+PRs and issue reports are welcome.
 
----
+If this project helps your workflow, starring the repo is the easiest way to support it:
+<https://github.com/michaelmjhhhh/TodoFocus>
 
 ## License
 
-[AGPL-3.0](LICENSE) — See [LICENSE](LICENSE) for details.
+[AGPL-3.0](LICENSE)


### PR DESCRIPTION
## Summary\n- rewrite README to emphasize TodoFocus value proposition for focused execution\n- simplify quick start and streamline core feature explanation\n- add clearer project status, roadmap, and support CTA\n\n## Testing\n- not run (documentation-only change)