### PR TITLE
docs(readme): make landing message more compelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,72 @@
 # TodoFocus
 
 <p align="center">
-  <img src="assets/overdue-screenshot.png" alt="TodoFocus" width="900"/>
+  <img src="assets/overdue-screenshot.png" alt="TodoFocus Screenshot" width="960" />
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/macOS-14%2B-blue" alt="macOS 14+"/>
-  <img src="https://img.shields.io/badge/SwiftUI-orange" alt="SwiftUI"/>
-  <img src="https://img.shields.io/badge/Local--First-SQLite-yellow" alt="Local-first SQLite"/>
-  <img src="https://img.shields.io/github/v/release/michaelmjhhhh/TodoFocus" alt="Latest Release"/>
-  <img src="https://img.shields.io/github/license/michaelmjhhhh/TodoFocus" alt="License"/>
+  <a href="https://github.com/michaelmjhhhh/TodoFocus/releases"><img src="https://img.shields.io/github/v/release/michaelmjhhhh/TodoFocus?label=latest%20release" alt="Latest Release" /></a>
+  <img src="https://img.shields.io/badge/macOS-14%2B-0A84FF" alt="macOS 14+" />
+  <img src="https://img.shields.io/badge/Built%20With-SwiftUI-F2994A" alt="SwiftUI" />
+  <img src="https://img.shields.io/badge/Storage-Local%20SQLite-4F8A3D" alt="Local SQLite" />
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-2D2D2D" alt="License" /></a>
 </p>
 
-A local-first native macOS task app built for focused execution.
+<p align="center">
+  <strong>A local-first macOS task app for people who want to finish real work.</strong>
+</p>
 
-TodoFocus is designed for people who want to stay in flow: pick a task, launch context, block distractions, and finish.
+<p align="center">
+  Pick a task. Launch your context. Block distractions. Ship.
+</p>
 
-## Why It Exists
+## Why TodoFocus
 
-Most todo apps are good at storing tasks but weak at helping you execute.
+Most todo apps are great at collecting tasks and weak at execution.
 
-TodoFocus prioritizes execution speed:
-- Start a focus session directly from a task
-- Launch all related resources with one click
-- Keep everything local and fast (no account, no sync setup)
+TodoFocus is built around one question: <strong>how fast can you move from "I should do this" to deep, uninterrupted execution?</strong>
 
-## Core Features
+- `No account, no cloud setup`: runs locally with SQLite
+- `Focus-first workflow`: start Deep Focus from the selected task
+- `Context Launchpad`: open URLs/files/apps tied to the task in one click
+- `Quick Capture (⌘⇧T)`: capture ideas instantly without leaving current app
 
-- `Deep Focus`: timed or infinite focus sessions with blocked apps and session stats
-- `Hard Focus`: stricter lock mode for stronger distraction control
-- `Quick Capture` (`⌘⇧T`): capture ideas globally while working in other apps
-- `Context Launchpad`: attach URL/file/app resources to any task and launch all
-- `Per-view filtering`: overdue, today, tomorrow, next 7 days, no date
-- `Search` (`⌘K`): find tasks by title and notes
-- `My Day`: daily intent list for high-priority execution
+## What Makes It Different
 
-## Quick Start
+| Typical Todo App | TodoFocus |
+|---|---|
+| Organize tasks | Execute tasks |
+| Manual context switching | `Launch All` restores working context |
+| Easy to get distracted | Deep/Hard Focus can block distraction paths |
+| Notes live in one place | Quick Capture injects thoughts during active focus |
 
-### Option 1: Use Release Build (recommended)
+## Core Capabilities
 
-1. Open Releases: <https://github.com/michaelmjhhhh/TodoFocus/releases>
-2. Download latest `TodoFocus-macos-universal.zip`
-3. Unzip and move `TodoFocusMac.app` to Applications
+### Execution
+- `Deep Focus`: timed or infinite sessions with stats tracking
+- `Hard Focus`: stronger lock mode for strict focus windows
+- `Session completion`: timer-based session completion flow with task progress updates
 
-### Option 2: Build From Source
+### Tasking
+- Smart views: overdue, today, tomorrow, next 7 days, no date
+- Custom lists with color indicators
+- My Day list for daily priorities
+- Search (`⌘K`) across titles and notes
+
+### Context Launchpad
+- Attach `url`, `file`, `app` resources per task
+- Click `Launch All` to restore work context instantly
+- Native macOS launch behavior (no shell command execution)
+
+## Install
+
+### Recommended: Download Release
+
+1. Open: <https://github.com/michaelmjhhhh/TodoFocus/releases>
+2. Download `TodoFocus-macos-universal.zip`
+3. Unzip and move `TodoFocusMac.app` to `Applications`
+
+### Build From Source
 
 ```bash
 brew install xcodegen
@@ -53,48 +76,43 @@ xcodegen generate
 xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
 ```
 
-First launch may require Accessibility permission for global quick capture:
+## First-Run Permissions
+
+For global quick capture (`⌘⇧T`), grant Accessibility permission:
 `System Settings -> Privacy & Security -> Accessibility`
 
 ## Keyboard Shortcuts
 
 | Shortcut | Action |
 |---|---|
-| `⌘⇧T` | Quick Capture (global hotkey) |
-| `⌘⇧F` | Start Deep Focus on selected task |
+| `⌘⇧T` | Quick Capture (global) |
+| `⌘⇧F` | Start Deep Focus for selected task |
 | `⌘⇧N` | Add new task |
-| `⌘K` | Search tasks |
+| `⌘K` | Search |
 
 ## Data and Privacy
 
 - Local-first by default
-- SQLite database path: `~/Library/Application Support/todofocus/todofocus.db`
-- Import/Export supports backup-safe replace and merge workflows
+- Database path: `~/Library/Application Support/todofocus/todofocus.db`
+- Import/Export includes backup-safe replace and merge modes
 
 ## Project Status
 
 Actively maintained.
 
-If you test it and something feels off, open an issue with:
-- what you did
-- what you expected
-- what actually happened
-- your macOS version
+If you run into a bug, open an issue with:
+- reproduction steps
+- expected behavior
+- actual behavior
+- macOS version
 
-Issue tracker: <https://github.com/michaelmjhhhh/TodoFocus/issues>
+Issues: <https://github.com/michaelmjhhhh/TodoFocus/issues>
 
-## Roadmap (Short Term)
+## If This Helps You
 
-- Improve import/export UX and reliability
-- Continue hard-focus/deep-focus edge-case hardening
-- Polish onboarding and first-run clarity
-
-## Contributing
-
-PRs and issue reports are welcome.
-
-If this project helps your workflow, starring the repo is the easiest way to support it:
-<https://github.com/michaelmjhhhh/TodoFocus>
+- Star the repo: <https://github.com/michaelmjhhhh/TodoFocus>
+- Share it with one macOS productivity nerd friend
+- Open an issue with your workflow pain points
 
 ## License
 


### PR DESCRIPTION
## Summary\n- redesign README hero section to be more product-like and attention-grabbing\n- sharpen value proposition around execution and focus outcomes\n- simplify install/onboarding and strengthen support CTA\n\n## Testing\n- not run (documentation-only change)