### PR TITLE
fix(due-date): avoid overdue flicker when selecting today

### DIFF
--- a/macos/TodoFocusMac/Sources/Core/Models/Todo.swift
+++ b/macos/TodoFocusMac/Sources/Core/Models/Todo.swift
@@ -12,14 +12,25 @@ struct Todo: Identifiable, Equatable {
     var launchResourcesRaw: String
     var focusTimeSeconds: Int = 0
 
-    var debtSeconds: Int? {
-        guard !isCompleted, let dueDate = dueDate else { return nil }
-        let diff = Int(Date().timeIntervalSince(dueDate))
+    func debtSeconds(at now: Date = Date(), calendar: Calendar = .current) -> Int? {
+        guard !isCompleted, let dueDate else { return nil }
+
+        // Due date is day-based in the UI, so a task should only become overdue
+        // after the local due day has fully passed.
+        let dueDay = calendar.startOfDay(for: dueDate)
+        let nowDay = calendar.startOfDay(for: now)
+        guard dueDay < nowDay else { return nil }
+
+        let diff = Int(now.timeIntervalSince(dueDate))
         guard diff > 0 else { return nil }
         return diff
     }
 
-    var isOverdue: Bool {
-        debtSeconds != nil
+    var debtSeconds: Int? { debtSeconds() }
+
+    func isOverdue(at now: Date = Date(), calendar: Calendar = .current) -> Bool {
+        debtSeconds(at: now, calendar: calendar) != nil
     }
+
+    var isOverdue: Bool { isOverdue() }
 }

--- a/macos/TodoFocusMac/Tests/CoreTests/TimeFilterTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/TimeFilterTests.swift
@@ -98,4 +98,42 @@ final class TimeFilterTests: XCTestCase {
         XCTAssertFalse(matches(filter: .tomorrow, dueDate: nil, isCompleted: false, now: now, calendar: calendar))
         XCTAssertFalse(matches(filter: .next7Days, dueDate: nil, isCompleted: false, now: now, calendar: calendar))
     }
+
+    func testTodoIsOverdueExcludesDatesEarlierToday() {
+        let now = date(2026, 3, 21, 23, 59)
+        let dueEarlierToday = date(2026, 3, 21, 0, 1)
+        let todo = Todo(
+            id: "todo-1",
+            title: "Task",
+            isCompleted: false,
+            isImportant: false,
+            isMyDay: false,
+            dueDate: dueEarlierToday,
+            notes: "",
+            listId: nil,
+            launchResourcesRaw: "[]"
+        )
+
+        XCTAssertFalse(todo.isOverdue(at: now, calendar: calendar))
+        XCTAssertNil(todo.debtSeconds(at: now, calendar: calendar))
+    }
+
+    func testTodoIsOverdueMatchesPreviousDay() {
+        let now = date(2026, 3, 21, 10)
+        let dueYesterday = date(2026, 3, 20, 23, 59)
+        let todo = Todo(
+            id: "todo-2",
+            title: "Task",
+            isCompleted: false,
+            isImportant: false,
+            isMyDay: false,
+            dueDate: dueYesterday,
+            notes: "",
+            listId: nil,
+            launchResourcesRaw: "[]"
+        )
+
+        XCTAssertTrue(todo.isOverdue(at: now, calendar: calendar))
+        XCTAssertNotNil(todo.debtSeconds(at: now, calendar: calendar))
+    }
 }


### PR DESCRIPTION
## Summary
- fix overdue logic to use local day boundaries instead of second-level comparison
- prevent tasks due earlier today from being shown as overdue
- keep previous-day tasks correctly marked overdue

## Changes
- update Todo.debtSeconds / Todo.isOverdue to support day-level comparison via calendar
- add regression tests in TimeFilterTests for same-day and previous-day behavior

## Validation
- xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" ✅
- xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:CoreTests/TimeFilterTests is still blocked by existing unrelated CoreTests actor-isolation compile failures in current baseline
