### PR TITLE
docs(readme): add macOS security unblock guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ What to look for in this demo:
 2. Download `TodoFocus-macos-universal.zip`
 3. Move `TodoFocusMac.app` to `Applications`
 
+### If macOS Blocks the App ("Malware" / "Damaged" Warning)
+If macOS prevents launch because the app is from an unidentified developer or is flagged as potentially harmful:
+
+1. Try opening `TodoFocusMac.app` once from `Applications` (let it fail).
+2. Open `System Settings -> Privacy & Security`.
+3. Scroll to the Security section and find the message about `TodoFocusMac.app`.
+4. Click `Open Anyway`.
+5. Confirm again in the follow-up dialog (`Open`).
+
+If you still see a warning, right-click the app in `Applications`, choose `Open`, then confirm once more. After this, macOS should trust future launches.
+
 ### Build From Source
 
 ```bash


### PR DESCRIPTION
## Summary\n- add a dedicated install note for Gatekeeper/malware warnings\n- document the Privacy & Security -> Open Anyway flow\n- include right-click Open fallback for first launch\n\n## Why\nUsers may be blocked on first run by macOS security checks and need clear manual steps to continue.