### PR TITLE
fix(tests): restore macOS test suite after actor/API drift

### DIFF
--- a/docs/superpowers/issues/2026-03-29-test-suite-regression-mainactor-api-drift.md
+++ b/docs/superpowers/issues/2026-03-29-test-suite-regression-mainactor-api-drift.md
@@ -1,0 +1,36 @@
+# Test Suite Regression: MainActor/API Drift Causes `xcodebuild test` Failure
+
+## Summary
+`xcodebuild test` currently fails at compile time in `CoreTests` due to drift between production API changes and test code assumptions.
+
+## Reproduction
+From repo root:
+
+```bash
+cd macos/TodoFocusMac
+xcodegen generate
+xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
+```
+
+## Observed Failures
+1. Main actor isolation violations in test files using `AppModel` from non-`@MainActor` test contexts.
+2. `DeepFocusService.startSession` signature mismatch (`duration` parameter now required).
+3. `DeepFocusService.stats` access in tests despite `stats` being `private`.
+4. `CoreTodo` initializer mismatch in tests after adding `isCompleted` field.
+
+## Root Cause
+Recent production changes tightened actor isolation and updated model/service APIs, but related tests were not updated in lockstep.
+
+## Scope
+- `Tests/CoreTests/AppModelTests.swift`
+- `Tests/CoreTests/AppSelectionStateTests.swift`
+- `Tests/CoreTests/DeepFocusServiceTests.swift`
+- `Tests/CoreTests/TodoQueryTests.swift`
+
+## Acceptance Criteria
+- `xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"` passes.
+- Changes are limited to test compatibility updates and do not alter production behavior.
+- Test assertions for Deep Focus stats rely on public behavior (`DeepFocusReport`) rather than private internals.
+
+## Notes
+Separate warning exists in Xcode project generation regarding duplicate group memberships for `Sources/Data/*` paths. This issue tracks test failures only.

--- a/docs/superpowers/prs/2026-03-29-fix-73-test-suite-mainactor-api-drift.md
+++ b/docs/superpowers/prs/2026-03-29-fix-73-test-suite-mainactor-api-drift.md
@@ -1,0 +1,30 @@
+## Summary
+Closes #73.
+
+Aligns tests with current production API and actor isolation rules so `xcodebuild test` passes again.
+
+## What Changed
+- Updated Core test files to respect `@MainActor` isolation for `AppModel` / `TodoAppStore` usage.
+- Updated tests to match current API signatures and model fields:
+  - `DeepFocusService.startSession(..., duration:, ...)`
+  - `CoreTodo.isCompleted`
+- Replaced Deep Focus stats assertions in tests to use public report output instead of private service internals.
+- Removed outdated test that referenced removed API `TaskDetailView.shouldShowDueDateClearButton`.
+- Fixed `AgentHeartbeatRecord` GRDB column mapping by adding explicit `CodingKeys` for snake_case DB columns.
+
+## Why
+Recent production changes (actor isolation + API evolution + schema naming) caused test compile/runtime failures. This PR restores test compatibility without changing product behavior.
+
+## Verification
+Ran on macOS locally:
+
+```bash
+cd macos/TodoFocusMac
+xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
+xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
+```
+
+Both commands succeeded.
+
+## Notes
+`xcodebuild` still reports existing project warnings about duplicate file-reference group membership under `Sources/Data/*`. Not changed in this PR.

--- a/macos/TodoFocusMac/Sources/Data/DTO/AgentHeartbeatRecord.swift
+++ b/macos/TodoFocusMac/Sources/Data/DTO/AgentHeartbeatRecord.swift
@@ -8,4 +8,10 @@ struct AgentHeartbeatRecord: Codable, FetchableRecord, PersistableRecord {
     var agentId: String
     var lastHeartbeat: Date
     var currentSessionId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case agentId = "agent_id"
+        case lastHeartbeat = "last_heartbeat"
+        case currentSessionId = "current_session_id"
+    }
 }

--- a/macos/TodoFocusMac/Tests/CoreTests/AppModelTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/AppModelTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import TodoFocusMac
 
+@MainActor
 final class AppModelTests: XCTestCase {
     func testDefaultDetailPanelWidth() {
         UserDefaults.standard.removeObject(forKey: WindowPersistence.detailWidthKey)

--- a/macos/TodoFocusMac/Tests/CoreTests/AppSelectionStateTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/AppSelectionStateTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import TodoFocusMac
 
+@MainActor
 final class AppSelectionStateTests: XCTestCase {
     func testSidebarSelectionChangeClearsSelectedTodo() {
         let model = AppModel()

--- a/macos/TodoFocusMac/Tests/CoreTests/DeepFocusServiceTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/DeepFocusServiceTests.swift
@@ -6,22 +6,22 @@ final class DeepFocusServiceTests: XCTestCase {
     func testStatsAccumulation() {
         let service = DeepFocusService()
         
-        service.startSession(blockedApps: [], focusTaskId: "test-task-id")
-        service.endSession()
+        service.startSession(blockedApps: [], duration: nil, focusTaskId: "test-task-id")
+        let report = service.endSession()
         
-        XCTAssertEqual(service.stats.sessionCount, 1)
-        XCTAssertGreaterThan(service.stats.totalFocusTime, 0)
+        XCTAssertEqual(report?.stats.sessionCount, 1)
+        XCTAssertGreaterThan(report?.stats.totalFocusTime ?? 0, 0)
     }
     
     func testDistractionTracking() {
         let service = DeepFocusService()
         
-        service.startSession(blockedApps: [], focusTaskId: "test-task-id")
+        service.startSession(blockedApps: [], duration: nil, focusTaskId: "test-task-id")
         service.recordDistraction(appBundleId: "com.apple.Safari", appName: "Safari")
         service.recordDistraction(appBundleId: "com.apple.Safari", appName: "Safari")
         service.recordDistraction(appBundleId: "com.apple.Mail", appName: "Mail")
-        service.endSession()
+        let report = service.endSession()
         
-        XCTAssertEqual(service.stats.distractionCount, 3)
+        XCTAssertEqual(report?.stats.distractionCount, 3)
     }
 }

--- a/macos/TodoFocusMac/Tests/CoreTests/FeatureBehaviorTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/FeatureBehaviorTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 @testable import TodoFocusMac
 
+@MainActor
 final class FeatureBehaviorTests: XCTestCase {
     func testSelectingSidebarClearsSelectedTask() {
         let model = AppModel()

--- a/macos/TodoFocusMac/Tests/CoreTests/SmartListFilterTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/SmartListFilterTests.swift
@@ -114,6 +114,7 @@ final class SmartListFilterTests: XCTestCase {
         id: String,
         isMyDay: Bool = false,
         isImportant: Bool = false,
+        isCompleted: Bool = false,
         dueDate: Date? = nil,
         listId: String? = nil
     ) -> CoreTodo {
@@ -121,6 +122,7 @@ final class SmartListFilterTests: XCTestCase {
             id: id,
             isMyDay: isMyDay,
             isImportant: isImportant,
+            isCompleted: isCompleted,
             dueDate: dueDate,
             listId: listId
         )

--- a/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreSelectionTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreSelectionTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 @testable import TodoFocusMac
 
+@MainActor
 final class TodoAppStoreSelectionTests: XCTestCase {
     func testSelectAndClearSelectionUpdatesSelectedTodo() throws {
         let now = Date(timeIntervalSince1970: 1_763_520_000)

--- a/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 @testable import TodoFocusMac
 
+@MainActor
 final class TodoAppStoreTests: XCTestCase {
     private func makeStore(now: Date = Date(timeIntervalSince1970: 1_763_520_000)) throws -> (TodoAppStore, AppModel, ListRepository, TodoRepository) {
         let path = NSTemporaryDirectory() + UUID().uuidString + ".sqlite"
@@ -217,11 +218,6 @@ final class TodoAppStoreTests: XCTestCase {
 
         let persisted = try XCTUnwrap(todoRepository.fetchTodo(id: created.id))
         XCTAssertEqual(persisted.notes, "second")
-    }
-
-    func testDueDateClearButtonVisibilityHelper() {
-        XCTAssertFalse(TaskDetailView.shouldShowDueDateClearButton(dueDate: nil))
-        XCTAssertTrue(TaskDetailView.shouldShowDueDateClearButton(dueDate: Date(timeIntervalSince1970: 1_763_520_000)))
     }
 
     func testDeleteActiveCustomListRoutesSelectionToAll() throws {

--- a/macos/TodoFocusMac/Tests/CoreTests/TodoQueryTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/TodoQueryTests.swift
@@ -40,9 +40,17 @@ final class TodoQueryTests: XCTestCase {
         id: String,
         isMyDay: Bool = false,
         isImportant: Bool = false,
+        isCompleted: Bool = false,
         dueDate: Date? = nil,
         listId: String? = nil
     ) -> CoreTodo {
-        CoreTodo(id: id, isMyDay: isMyDay, isImportant: isImportant, dueDate: dueDate, listId: listId)
+        CoreTodo(
+            id: id,
+            isMyDay: isMyDay,
+            isImportant: isImportant,
+            isCompleted: isCompleted,
+            dueDate: dueDate,
+            listId: listId
+        )
     }
 }


### PR DESCRIPTION
## Summary
Closes #73.

Aligns tests with current production API and actor isolation rules so `xcodebuild test` passes again.

## What Changed
- Updated Core test files to respect `@MainActor` isolation for `AppModel` / `TodoAppStore` usage.
- Updated tests to match current API signatures and model fields:
  - `DeepFocusService.startSession(..., duration:, ...)`
  - `CoreTodo.isCompleted`
- Replaced Deep Focus stats assertions in tests to use public report output instead of private service internals.
- Removed outdated test that referenced removed API `TaskDetailView.shouldShowDueDateClearButton`.
- Fixed `AgentHeartbeatRecord` GRDB column mapping by adding explicit `CodingKeys` for snake_case DB columns.

## Why
Recent production changes (actor isolation + API evolution + schema naming) caused test compile/runtime failures. This PR restores test compatibility without changing product behavior.

## Verification
Ran on macOS locally:

```bash
cd macos/TodoFocusMac
xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
```

Both commands succeeded.

## Notes
`xcodebuild` still reports existing project warnings about duplicate file-reference group membership under `Sources/Data/*`. Not changed in this PR.
