### PR TITLE
build(xcodegen): remove duplicate group-membership warnings

### DIFF
--- a/docs/superpowers/issues/2026-03-29-xcodegen-duplicate-group-membership-warning.md
+++ b/docs/superpowers/issues/2026-03-29-xcodegen-duplicate-group-membership-warning.md
@@ -1,0 +1,26 @@
+# xcodegen warning: duplicate file-reference group membership for Sources/Data/*
+
+## Summary
+`xcodebuild` currently emits warnings after project generation:
+
+- `Sources/Data/Database` member of multiple groups
+- `Sources/Data/DTO` member of multiple groups
+- `Sources/Data/Repositories` member of multiple groups
+
+## Reproduction
+```bash
+cd macos/TodoFocusMac
+xcodegen generate
+xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
+```
+
+## Suspected Root Cause
+In `project.yml`, app target includes broad `Sources` path while agent target separately lists multiple files under `Sources/Data/*`, which can produce malformed group membership in generated project structure.
+
+## Scope
+- `macos/TodoFocusMac/project.yml`
+- generated `macos/TodoFocusMac/TodoFocusMac.xcodeproj/project.pbxproj` (if needed)
+
+## Acceptance Criteria
+- `xcodegen generate` + `xcodebuild build` no longer emits duplicate group-membership warnings.
+- Build/test behavior remains unchanged.

--- a/docs/superpowers/prs/2026-03-29-fix-75-xcodegen-duplicate-group-warning.md
+++ b/docs/superpowers/prs/2026-03-29-fix-75-xcodegen-duplicate-group-warning.md
@@ -1,0 +1,25 @@
+## Summary
+Closes #75.
+
+Removes Xcode-generated malformed group membership warnings by simplifying `TodoFocusAgent` source declarations in `project.yml`.
+
+## What Changed
+- Updated `macos/TodoFocusMac/project.yml`:
+  - `TodoFocusAgent.sources` now uses a single `path: Sources` entry with `includes` for agent-specific files.
+  - Replaced multiple mixed `Sources/Agent` + `Sources/Data/*` entries that were causing duplicate file-reference group memberships.
+
+## Why
+`xcodebuild` warnings showed `Sources/Data/Database`, `Sources/Data/DTO`, and `Sources/Data/Repositories` as members of multiple groups. This made generated project structure malformed/noisy.
+
+## Verification
+```bash
+cd macos/TodoFocusMac
+xcodegen generate
+xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
+xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
+```
+
+Results:
+- Build succeeded.
+- Tests succeeded.
+- Duplicate group-membership warnings are no longer emitted.

--- a/macos/TodoFocusMac/project.yml
+++ b/macos/TodoFocusMac/project.yml
@@ -42,12 +42,14 @@ targets:
     type: tool
     platform: macOS
     sources:
-      - path: Sources/Agent
-      - path: Sources/Data/Database/Migrations.swift
-      - path: Sources/Data/DTO/HardFocusSessionRecord.swift
-      - path: Sources/Data/DTO/AgentHeartbeatRecord.swift
-      - path: Sources/Data/Database/DatabaseManager.swift
-      - path: Sources/Data/Repositories/HardFocusSessionRepository.swift
+      - path: Sources
+        includes:
+          - Agent/**
+          - Data/Database/Migrations.swift
+          - Data/DTO/HardFocusSessionRecord.swift
+          - Data/DTO/AgentHeartbeatRecord.swift
+          - Data/Database/DatabaseManager.swift
+          - Data/Repositories/HardFocusSessionRepository.swift
     settings:
       base:
         PRODUCT_NAME: TodoFocusAgent


### PR DESCRIPTION
## Summary
Closes #75.

Removes Xcode-generated malformed group membership warnings by simplifying `TodoFocusAgent` source declarations in `project.yml`.

## What Changed
- Updated `macos/TodoFocusMac/project.yml`:
  - `TodoFocusAgent.sources` now uses a single `path: Sources` entry with `includes` for agent-specific files.
  - Replaced multiple mixed `Sources/Agent` + `Sources/Data/*` entries that were causing duplicate file-reference group memberships.

## Why
`xcodebuild` warnings showed `Sources/Data/Database`, `Sources/Data/DTO`, and `Sources/Data/Repositories` as members of multiple groups. This made generated project structure malformed/noisy.

## Verification
```bash
cd macos/TodoFocusMac
xcodegen generate
xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
```

Results:
- Build succeeded.
- Tests succeeded.
- Duplicate group-membership warnings are no longer emitted.
