### PR TITLE
feat(macos): add deep focus menu bar status panel

### DIFF
--- a/docs/superpowers/issues/2026-03-29-deep-focus-menubar-status.md
+++ b/docs/superpowers/issues/2026-03-29-deep-focus-menubar-status.md
@@ -1,0 +1,39 @@
+# Feature: Deep Focus Menu Bar Status Panel (macOS)
+
+## Summary
+Add a native macOS Menu Bar status entry for Deep Focus using SwiftUI `MenuBarExtra`.
+
+## Goals
+- Show real-time Deep Focus status directly from menu bar.
+- Provide quick actions:
+  - Open TodoFocus main window.
+  - End current Deep Focus session.
+  - Quit app.
+- Keep existing Deep Focus/Hard Focus logic unchanged.
+
+## UX / Visual Requirements
+- Must feel smooth and responsive (no badge flicker / jumpy width changes).
+- Reuse existing app visual language:
+  - `ThemeTokens` (`panelBackground`, `sectionBorder`, `textPrimary`, `textSecondary`, `accentTerracotta`)
+  - `MotionTokens` (`hoverEase`, `focusEase`, `panelSpring`)
+- Keep click targets >= 44pt and keyboard accessible labels.
+
+## Functional Requirements
+- Use `MenuBarExtra(...).menuBarExtraStyle(.window)`.
+- Read state from existing observable chain: `AppModel.deepFocusService` + `TodoAppStore`.
+- Support timed sessions with compact remaining-time badge in menu bar label.
+- `End Deep Focus` disabled when no active session.
+- `Open TodoFocus` should reliably bring app to front and open/create main window.
+
+## Technical Constraints
+- SwiftUI-first implementation.
+- Use `swiftui-expert-skill` and `ui-ux-pro-max` standards.
+- No behavior changes to focus session business rules.
+- Follow TDD for new mapping logic.
+
+## Acceptance Criteria
+- Menu bar status appears and updates correctly when Deep Focus starts/ends.
+- Timed session badge updates smoothly.
+- End Focus action calls existing store end flow and works safely.
+- Open action reliably foregrounds main window.
+- Full test suite and release build pass.

--- a/docs/superpowers/plans/2026-03-29-deep-focus-menubar-status-plan.md
+++ b/docs/superpowers/plans/2026-03-29-deep-focus-menubar-status-plan.md
@@ -1,0 +1,205 @@
+# Deep Focus Menu Bar Status Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.  
+> **Model requirement:** When parallelizing with subagents, use `gpt-5.3-codex` for all workers.
+
+**Goal:** Add a polished macOS menu bar status entry that shows Deep Focus state in real time and provides fast actions (open main window, end focus) without changing existing focus business logic.
+
+**Architecture:** Add a `MenuBarExtra` scene at app entry and drive it from existing observable state (`AppModel.deepFocusService` + `TodoAppStore`). Build a dedicated SwiftUI panel component under `Features/MenuBar` that reuses `ThemeTokens`/`MotionTokens` and only calls existing store APIs for side effects. Add a small pure state mapper for deterministic UI labels/countdown and unit-test it.
+
+**Tech Stack:** SwiftUI macOS scenes (`MenuBarExtra`, `WindowGroup`), Observation (`@Observable`, `@Bindable`), existing ThemeTokens/MotionTokens, XCTest.
+
+---
+
+## Chunk 1: Scene Wiring + State Model
+
+### Task 1: Add testable menu bar state mapper (TDD first)
+
+**Files:**
+- Create: `macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarState.swift`
+- Create: `macos/TodoFocusMac/Tests/CoreTests/DeepFocusMenuBarStateTests.swift`
+
+- [ ] **Step 1: Write failing tests for state text and countdown formatting**
+
+```swift
+func testInactiveStateLabel() {
+    let state = DeepFocusMenuBarState.from(
+        isActive: false,
+        startedAt: nil,
+        configuredDuration: nil,
+        blockedAppCount: 0,
+        now: Date(timeIntervalSince1970: 1000)
+    )
+    XCTAssertEqual(state.title, "Deep Focus")
+    XCTAssertEqual(state.subtitle, "Idle")
+}
+
+func testActiveTimedStateShowsRemaining() {
+    let start = Date(timeIntervalSince1970: 1000)
+    let now = Date(timeIntervalSince1970: 1060)
+    let state = DeepFocusMenuBarState.from(
+        isActive: true,
+        startedAt: start,
+        configuredDuration: 25 * 60,
+        blockedAppCount: 3,
+        now: now
+    )
+    XCTAssertEqual(state.menuBarBadge, "24m")
+    XCTAssertTrue(state.subtitle.contains("3 apps"))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:CoreTests/DeepFocusMenuBarStateTests`  
+Expected: FAIL (new type not found).
+
+- [ ] **Step 3: Implement minimal state mapper**
+
+Implementation requirements:
+- Build a pure struct with no SwiftUI dependency.
+- Inputs: `isActive`, `startedAt`, `configuredDuration`, `blockedAppCount`, `now`.
+- Outputs: `title`, `subtitle`, `menuBarBadge`, `isActive`.
+- Timed session formatting uses minute granularity and clamps at `0m`.
+
+- [ ] **Step 4: Re-run tests and ensure pass**
+
+Run: same `xcodebuild ... -only-testing` command  
+Expected: PASS.
+
+- [ ] **Step 5: Commit chunk**
+
+```bash
+git add macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarState.swift \
+        macos/TodoFocusMac/Tests/CoreTests/DeepFocusMenuBarStateTests.swift
+git commit -m "test+feat(menubar): add deep focus menu bar state mapper"
+```
+
+### Task 2: Expose session start time safely for countdown
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Sources/App/DeepFocusService.swift`
+- Modify: `macos/TodoFocusMac/Tests/CoreTests/DeepFocusServiceTests.swift`
+
+- [ ] **Step 1: Add failing test for observable start timestamp**
+
+Test target behavior:
+- After `startSession`, `sessionStartedAt` is non-nil.
+- After `endSession`, `sessionStartedAt` becomes nil.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:CoreTests/DeepFocusServiceTests`  
+Expected: FAIL (property missing).
+
+- [ ] **Step 3: Implement minimal API surface**
+
+Implementation requirements:
+- Add `var sessionStartedAt: Date? { sessionStartTime }` read-only computed property.
+- Keep existing private storage and session behavior unchanged.
+
+- [ ] **Step 4: Re-run tests and ensure pass**
+
+Run: same `xcodebuild ... -only-testing` command  
+Expected: PASS.
+
+- [ ] **Step 5: Commit chunk**
+
+```bash
+git add macos/TodoFocusMac/Sources/App/DeepFocusService.swift \
+        macos/TodoFocusMac/Tests/CoreTests/DeepFocusServiceTests.swift
+git commit -m "feat(deep-focus): expose session start timestamp for status surfaces"
+```
+
+---
+
+## Chunk 2: MenuBarExtra UI + Actions + Verification
+
+### Task 3: Build polished MenuBar panel view (UI/UX + SwiftUI best practices)
+
+**Files:**
+- Create: `macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift`
+- Modify: `macos/TodoFocusMac/Sources/TodoFocusMacApp.swift`
+
+- [ ] **Step 1: Implement MenuBar panel layout using existing design tokens**
+
+Implementation requirements (use `ui-ux-pro-max` + `swiftui-expert-skill`):
+- Reuse `ThemeTokens` colors: `panelBackground`, `sectionBorder`, `textPrimary`, `textSecondary`, `accentTerracotta`.
+- Reuse `MotionTokens` for hover/focus transitions (`hoverEase`, `focusEase`).
+- Keep touch/click targets >= 44pt and keyboard accessible labels.
+- Hierarchy: status title -> context subtitle -> actions row.
+
+- [ ] **Step 2: Wire real state from store/appModel**
+
+Implementation requirements:
+- Observe `store.deepFocusService` and map to `DeepFocusMenuBarState`.
+- Menu bar label: icon + compact badge when active timed session exists.
+- Panel body: show blocked app count and remaining/active status.
+
+- [ ] **Step 3: Add menu actions**
+
+Implementation requirements:
+- `Open TodoFocus`: open/create main window and bring app front (`openWindow(id: "main")` + `NSApp.activate(ignoringOtherApps: true)`).
+- `End Deep Focus`: `Task { @MainActor in _ = await store.endDeepFocus() }`, disabled when inactive.
+- `Quit`: `NSApplication.shared.terminate(nil)`.
+
+- [ ] **Step 4: Add `MenuBarExtra` scene and stable main window id**
+
+Implementation requirements:
+- In `TodoFocusMacApp`, give primary window scene a stable id (`WindowGroup(id: "main")`).
+- Add `MenuBarExtra(...).menuBarExtraStyle(.window)` scene next to existing `WindowGroup`/`Settings`.
+- Pass shared `appModel`, `store`, `themeStore` into panel.
+
+- [ ] **Step 5: Commit chunk**
+
+```bash
+git add macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift \
+        macos/TodoFocusMac/Sources/TodoFocusMacApp.swift
+git commit -m "feat(menubar): add deep focus status panel with quick actions"
+```
+
+### Task 4: Full verification + UX acceptance
+
+**Files:**
+- N/A (verification commands only)
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+`xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:CoreTests/DeepFocusMenuBarStateTests -only-testing:CoreTests/DeepFocusServiceTests`
+
+Expected:
+- PASS.
+
+- [ ] **Step 2: Run full test suite**
+
+Run:
+`xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+
+Expected:
+- `** TEST SUCCEEDED **`
+
+- [ ] **Step 3: Run release build**
+
+Run:
+`xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+
+Expected:
+- `** BUILD SUCCEEDED **`
+
+- [ ] **Step 4: Manual UX checklist (silky interaction gate)**
+
+Checklist:
+- Menu bar icon appears immediately and does not flicker during state changes.
+- Active session updates badge/remaining text smoothly (no jumpy width shifts).
+- End Focus action reflects state instantly and safely disables when inactive.
+- Open TodoFocus reliably brings main window front from background/minimized states.
+- Colors/spacing/motion match existing dark theme style.
+
+- [ ] **Step 5: Final commit + PR flow**
+
+```bash
+git add -A
+git commit -m "feat(macos): add deep focus menubar status"
+# issue -> branch -> PR using docs/superpowers/issues and docs/superpowers/prs templates
+```

--- a/docs/superpowers/prs/2026-03-29-feat-79-deep-focus-menubar-status.md
+++ b/docs/superpowers/prs/2026-03-29-feat-79-deep-focus-menubar-status.md
@@ -1,0 +1,36 @@
+## Summary
+Closes #79.
+
+Adds a polished native macOS Menu Bar status panel for Deep Focus using `MenuBarExtra(.window)`, with quick actions to open app, end focus, and quit.
+
+## What Changed
+- Added menu bar state model + tests:
+  - `macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarState.swift`
+  - `macos/TodoFocusMac/Tests/CoreTests/DeepFocusMenuBarStateTests.swift`
+- Added menu bar UI panel and label:
+  - `macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift`
+- Wired app scenes for menu bar entry + stable main window id:
+  - `macos/TodoFocusMac/Sources/TodoFocusMacApp.swift`
+- Exposed read-only session start timestamp for countdown formatting + tests:
+  - `macos/TodoFocusMac/Sources/App/DeepFocusService.swift`
+  - `macos/TodoFocusMac/Tests/CoreTests/DeepFocusServiceTests.swift`
+- Added workflow docs:
+  - `docs/superpowers/issues/2026-03-29-deep-focus-menubar-status.md`
+  - `docs/superpowers/plans/2026-03-29-deep-focus-menubar-status-plan.md`
+
+## Why
+This gives Deep Focus immediate visibility and control from the menu bar, reducing context switching and aligning with macOS-native productivity patterns.
+
+## Verification
+```bash
+cd macos/TodoFocusMac
+xcodegen generate
+xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:CoreTests/DeepFocusMenuBarStateTests -only-testing:CoreTests/DeepFocusServiceTests
+xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
+xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
+```
+
+Results:
+- Focused tests succeeded.
+- Full tests succeeded.
+- Release build succeeded.

--- a/macos/TodoFocusMac/Sources/App/DeepFocusService.swift
+++ b/macos/TodoFocusMac/Sources/App/DeepFocusService.swift
@@ -33,6 +33,7 @@ final class DeepFocusService {
     var currentSessionId: String?
     var currentFocusTaskId: String?
     var sessionDuration: TimeInterval?
+    var sessionStartedAt: Date? { sessionStartTime }
     var blockedApps: Set<String> = []
     var distractionAttempts: [String: Int] = [:]
     var distractionAppNames: [String: String] = [:]

--- a/macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift
+++ b/macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift
@@ -1,0 +1,261 @@
+import SwiftUI
+import AppKit
+
+@MainActor
+struct DeepFocusMenuBarPanel: View {
+    @Bindable var store: TodoAppStore
+    let themeStore: ThemeStore
+    let mainWindowID: String
+
+    @Environment(\.openWindow) private var openWindow
+    @State private var themeTokens: ThemeTokens
+    @State private var now: Date = .now
+
+    init(store: TodoAppStore, themeStore: ThemeStore, mainWindowID: String) {
+        self._store = Bindable(store)
+        self.themeStore = themeStore
+        self.mainWindowID = mainWindowID
+        self._themeTokens = State(initialValue: ThemeTokens(theme: themeStore.theme))
+    }
+
+    var body: some View {
+        let state = menuBarState(from: store, now: now)
+        let blockedAppCount = store.deepFocusService.blockedApps.count
+
+        VStack(alignment: .leading, spacing: 12) {
+            statusSection(state: state)
+            contextSection(state: state, blockedAppCount: blockedAppCount)
+
+            Divider()
+                .overlay(themeTokens.sectionBorder)
+
+            VStack(spacing: 8) {
+                MenuBarPanelActionButton(
+                    title: "Open TodoFocus",
+                    systemImage: "rectangle.inset.filled.and.person.filled",
+                    isDestructive: false,
+                    isDisabled: false
+                ) {
+                    openWindow(id: mainWindowID)
+                    NSApp.activate(ignoringOtherApps: true)
+                }
+
+                MenuBarPanelActionButton(
+                    title: "End Deep Focus",
+                    systemImage: "stop.circle.fill",
+                    isDestructive: true,
+                    isDisabled: !state.isActive
+                ) {
+                    Task { @MainActor in
+                        _ = await store.endDeepFocus()
+                    }
+                }
+
+                MenuBarPanelActionButton(
+                    title: "Quit",
+                    systemImage: "power",
+                    isDestructive: true,
+                    isDisabled: false
+                ) {
+                    NSApplication.shared.terminate(nil)
+                }
+            }
+        }
+        .padding(14)
+        .frame(width: 320)
+        .background(themeTokens.panelBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(themeTokens.sectionBorder, lineWidth: 1)
+        }
+        .shadow(color: themeTokens.textPrimary.opacity(0.18), radius: 10, y: 4)
+        .animation(MotionTokens.panelSpring, value: state.isActive)
+        .preferredColorScheme(themeStore.preferredColorScheme)
+        .themeMode(themeStore.theme)
+        .themeTokens(themeTokens)
+        .onReceive(Timer.publish(every: 15, on: .main, in: .common).autoconnect()) { timestamp in
+            now = timestamp
+        }
+        .onChange(of: themeStore.theme) { _, newTheme in
+            themeTokens = ThemeTokens(theme: newTheme)
+        }
+    }
+
+    @ViewBuilder
+    private func statusSection(state: DeepFocusMenuBarState) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: state.isActive ? "flame.fill" : "flame")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(state.isActive ? themeTokens.accentTerracotta : themeTokens.textSecondary)
+                .frame(width: 28, height: 28)
+                .background(themeTokens.bgFloating, in: RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(state.title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(themeTokens.textPrimary)
+                Text(state.subtitle)
+                    .font(.system(size: 12))
+                    .foregroundStyle(themeTokens.textSecondary)
+            }
+
+            Spacer(minLength: 8)
+
+            if let badge = state.menuBarBadge {
+                Text(badge)
+                    .font(.system(size: 11, weight: .semibold, design: .rounded).monospacedDigit())
+                    .foregroundStyle(themeTokens.accentTerracotta)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(themeTokens.bgFloating, in: Capsule())
+                    .overlay {
+                        Capsule()
+                            .stroke(themeTokens.sectionBorder, lineWidth: 1)
+                    }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func contextSection(state: DeepFocusMenuBarState, blockedAppCount: Int) -> some View {
+        HStack(spacing: 8) {
+            contextChip(title: "Blocked", value: "\(blockedAppCount) apps")
+            contextChip(
+                title: "Session",
+                value: state.menuBarBadge.map { "\($0) left" } ?? (state.isActive ? "Running" : "Idle")
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func contextChip(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(themeTokens.textSecondary)
+            Text(value)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(themeTokens.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(themeTokens.bgFloating, in: RoundedRectangle(cornerRadius: 10))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(themeTokens.sectionBorder, lineWidth: 1)
+        }
+    }
+}
+
+@MainActor
+struct DeepFocusMenuBarLabel: View {
+    @Bindable var store: TodoAppStore
+    @State private var now: Date = .now
+
+    init(store: TodoAppStore) {
+        self._store = Bindable(store)
+    }
+
+    var body: some View {
+        let state = menuBarState(from: store, now: now)
+
+        HStack(spacing: 4) {
+            Image(systemName: state.isActive ? "flame.fill" : "flame")
+                .font(.system(size: 13, weight: .semibold))
+
+            if let badge = state.menuBarBadge {
+                Text(badge)
+                    .font(.system(size: 11, weight: .semibold, design: .rounded).monospacedDigit())
+                    .frame(minWidth: 28, alignment: .leading)
+                    .transition(.opacity)
+            }
+        }
+        .animation(MotionTokens.focusEase, value: state.menuBarBadge ?? "")
+        .animation(MotionTokens.focusEase, value: state.isActive)
+        .onReceive(Timer.publish(every: 15, on: .main, in: .common).autoconnect()) { timestamp in
+            now = timestamp
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Deep Focus")
+        .accessibilityValue(store.deepFocusService.isActive ? "Active" : "Not active")
+    }
+}
+
+private struct MenuBarPanelActionButton: View {
+    let title: String
+    let systemImage: String
+    let isDestructive: Bool
+    let isDisabled: Bool
+    let action: () -> Void
+
+    @State private var isHovered: Bool = false
+    @Environment(\.themeTokens) private var themeTokens
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 13, weight: .semibold))
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(foregroundColor)
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            .contentShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+        .background(backgroundColor, in: RoundedRectangle(cornerRadius: 10))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(borderColor, lineWidth: 1)
+        }
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.55 : 1)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .animation(MotionTokens.hoverEase, value: isHovered)
+        .animation(MotionTokens.focusEase, value: isDisabled)
+        .accessibilityLabel(title)
+    }
+
+    private var foregroundColor: Color {
+        if isDisabled {
+            return themeTokens.textSecondary
+        }
+        return isDestructive ? themeTokens.danger : themeTokens.textPrimary
+    }
+
+    private var backgroundColor: Color {
+        if isDisabled {
+            return themeTokens.bgFloating.opacity(0.55)
+        }
+        if isHovered {
+            return isDestructive ? themeTokens.danger.opacity(0.12) : themeTokens.bgFloating
+        }
+        return themeTokens.bgFloating.opacity(0.88)
+    }
+
+    private var borderColor: Color {
+        if isHovered, !isDisabled {
+            return isDestructive ? themeTokens.danger.opacity(0.62) : themeTokens.accentTerracotta.opacity(0.5)
+        }
+        return themeTokens.sectionBorder
+    }
+}
+
+@MainActor
+private func menuBarState(from store: TodoAppStore, now: Date) -> DeepFocusMenuBarState {
+    DeepFocusMenuBarState.from(
+        isActive: store.deepFocusService.isActive,
+        sessionDuration: store.deepFocusService.sessionDuration,
+        sessionStartedAt: store.deepFocusService.sessionStartedAt,
+        now: now
+    )
+}

--- a/macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarState.swift
+++ b/macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarState.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+struct DeepFocusMenuBarState: Equatable {
+    let title: String
+    let subtitle: String
+    let menuBarBadge: String?
+    let isActive: Bool
+
+    static func from(
+        isActive: Bool,
+        sessionDuration: TimeInterval?,
+        sessionStartedAt: Date?,
+        now: Date = .now
+    ) -> DeepFocusMenuBarState {
+        guard isActive else {
+            return DeepFocusMenuBarState(
+                title: "Deep Focus",
+                subtitle: "Not active",
+                menuBarBadge: nil,
+                isActive: false
+            )
+        }
+
+        if let sessionDuration, let sessionStartedAt {
+            let elapsed = now.timeIntervalSince(sessionStartedAt)
+            let remainingSeconds = max(0, sessionDuration - elapsed)
+            let remainingMinutes = Int(ceil(remainingSeconds / 60.0))
+            let remaining = "\(remainingMinutes)m"
+
+            return DeepFocusMenuBarState(
+                title: "Deep Focus",
+                subtitle: "\(remaining) remaining",
+                menuBarBadge: remaining,
+                isActive: true
+            )
+        }
+
+        return DeepFocusMenuBarState(
+            title: "Deep Focus",
+            subtitle: "Active",
+            menuBarBadge: nil,
+            isActive: true
+        )
+    }
+
+    @MainActor
+    static func from(service: DeepFocusService, now: Date = .now) -> DeepFocusMenuBarState {
+        from(
+            isActive: service.isActive,
+            sessionDuration: service.sessionDuration,
+            sessionStartedAt: service.sessionStartedAt,
+            now: now
+        )
+    }
+}

--- a/macos/TodoFocusMac/Sources/TodoFocusMacApp.swift
+++ b/macos/TodoFocusMac/Sources/TodoFocusMacApp.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+private enum SceneIDs {
+    static let mainWindow = "main"
+}
+
 @main
 struct TodoFocusMacApp: App {
     @State private var appModel = AppModel()
@@ -37,7 +41,7 @@ struct TodoFocusMacApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup(id: SceneIDs.mainWindow) {
             Group {
                 if let store {
                     RootView(
@@ -65,6 +69,30 @@ struct TodoFocusMacApp: App {
         }
         .windowStyle(.hiddenTitleBar)
         .windowToolbarStyle(.unified(showsTitle: false))
+
+        MenuBarExtra {
+            Group {
+                if let store {
+                    DeepFocusMenuBarPanel(
+                        store: store,
+                        themeStore: themeStore,
+                        mainWindowID: SceneIDs.mainWindow
+                    )
+                } else {
+                    Text("TodoFocus unavailable")
+                        .font(.system(size: 12))
+                        .padding(12)
+                }
+            }
+            .preferredColorScheme(themeStore.preferredColorScheme)
+        } label: {
+            if let store {
+                DeepFocusMenuBarLabel(store: store)
+            } else {
+                Label("TodoFocus", systemImage: "checklist")
+            }
+        }
+        .menuBarExtraStyle(.window)
 
 #if os(macOS)
         Settings {

--- a/macos/TodoFocusMac/Tests/CoreTests/DeepFocusMenuBarStateTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/DeepFocusMenuBarStateTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import TodoFocusMac
+
+final class DeepFocusMenuBarStateTests: XCTestCase {
+    func testFromInactiveReturnsInactiveCopy() {
+        let now = Date(timeIntervalSince1970: 1_000)
+
+        let state = DeepFocusMenuBarState.from(
+            isActive: false,
+            sessionDuration: nil,
+            sessionStartedAt: nil,
+            now: now
+        )
+
+        XCTAssertEqual(state.title, "Deep Focus")
+        XCTAssertEqual(state.subtitle, "Not active")
+        XCTAssertNil(state.menuBarBadge)
+        XCTAssertFalse(state.isActive)
+    }
+
+    func testFromTimedSessionShowsRemainingMinutes() {
+        let sessionStartedAt = Date(timeIntervalSince1970: 1_000)
+        let now = Date(timeIntervalSince1970: 1_600)
+
+        let state = DeepFocusMenuBarState.from(
+            isActive: true,
+            sessionDuration: 25 * 60,
+            sessionStartedAt: sessionStartedAt,
+            now: now
+        )
+
+        XCTAssertEqual(state.subtitle, "15m remaining")
+        XCTAssertEqual(state.menuBarBadge, "15m")
+        XCTAssertTrue(state.isActive)
+    }
+
+    func testFromTimedSessionClampsRemainingMinutesToZero() {
+        let sessionStartedAt = Date(timeIntervalSince1970: 1_000)
+        let now = Date(timeIntervalSince1970: 2_600)
+
+        let state = DeepFocusMenuBarState.from(
+            isActive: true,
+            sessionDuration: 25 * 60,
+            sessionStartedAt: sessionStartedAt,
+            now: now
+        )
+
+        XCTAssertEqual(state.subtitle, "0m remaining")
+        XCTAssertEqual(state.menuBarBadge, "0m")
+        XCTAssertTrue(state.isActive)
+    }
+}

--- a/macos/TodoFocusMac/Tests/CoreTests/DeepFocusServiceTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/DeepFocusServiceTests.swift
@@ -24,4 +24,20 @@ final class DeepFocusServiceTests: XCTestCase {
         
         XCTAssertEqual(report?.stats.distractionCount, 3)
     }
+
+    func testSessionStartedAtExposedDuringSessionAndClearedAfterEnd() {
+        let service = DeepFocusService()
+
+        XCTAssertNil(service.sessionStartedAt)
+
+        service.startSession(blockedApps: [], duration: 25 * 60, focusTaskId: "test-task-id")
+
+        guard let sessionStartedAt = service.sessionStartedAt else {
+            return XCTFail("Expected sessionStartedAt while active session exists")
+        }
+        XCTAssertLessThanOrEqual(abs(sessionStartedAt.timeIntervalSinceNow), 1.0)
+
+        _ = service.endSession()
+        XCTAssertNil(service.sessionStartedAt)
+    }
 }


### PR DESCRIPTION
## Summary
Closes #79.

Adds a polished native macOS Menu Bar status panel for Deep Focus using `MenuBarExtra(.window)`, with quick actions to open app, end focus, and quit.

## What Changed
- Added menu bar state model + tests:
  - `macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarState.swift`
  - `macos/TodoFocusMac/Tests/CoreTests/DeepFocusMenuBarStateTests.swift`
- Added menu bar UI panel and label:
  - `macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift`
- Wired app scenes for menu bar entry + stable main window id:
  - `macos/TodoFocusMac/Sources/TodoFocusMacApp.swift`
- Exposed read-only session start timestamp for countdown formatting + tests:
  - `macos/TodoFocusMac/Sources/App/DeepFocusService.swift`
  - `macos/TodoFocusMac/Tests/CoreTests/DeepFocusServiceTests.swift`
- Added workflow docs:
  - `docs/superpowers/issues/2026-03-29-deep-focus-menubar-status.md`
  - `docs/superpowers/plans/2026-03-29-deep-focus-menubar-status-plan.md`

## Why
This gives Deep Focus immediate visibility and control from the menu bar, reducing context switching and aligning with macOS-native productivity patterns.

## Verification
```bash
cd macos/TodoFocusMac
xcodegen generate
xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:CoreTests/DeepFocusMenuBarStateTests -only-testing:CoreTests/DeepFocusServiceTests
xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
```

Results:
- Focused tests succeeded.
- Full tests succeeded.
- Release build succeeded.
