### PR TITLE
fix(menubar): passphrase end + quit cleanup + countdown/window sync

### DIFF
--- a/docs/superpowers/issues/2026-03-29-menubar-focus-quit-sync-and-countdown-off-by-one.md
+++ b/docs/superpowers/issues/2026-03-29-menubar-focus-quit-sync-and-countdown-off-by-one.md
@@ -1,0 +1,28 @@
+# Bugfix: MenuBar Quit Focus Cleanup + Countdown Off-by-One
+
+## Symptoms
+1. Quitting from MenuBar `Quit` then reopening can show focus mismatch:
+   - App may still show hard focus lock state.
+   - MenuBar shows inactive focus.
+2. Starting a 25-minute session sometimes shows `26m` in MenuBar.
+3. Ending focus from MenuBar currently does not require passphrase.
+4. Opening app from MenuBar can default to a full-screen style window behavior.
+5. MenuBar does not show which task is currently in Deep Focus.
+
+## Repro
+- Start Deep Focus with 25m duration.
+- Observe MenuBar badge may show `26m` at session start.
+- Quit app from MenuBar `Quit` or regular app quit.
+- Reopen app and observe status mismatch.
+
+## Root Cause
+- Quit path has no unified shutdown hook to end focus sessions before termination.
+- MenuBar minute calculation uses `ceil` on `sessionDuration - elapsed` without clamping negative elapsed when `now < sessionStartedAt` by a small timing delta.
+
+## Expected
+- Any app quit path triggers deterministic focus shutdown.
+- 25m session displays `25m` at start, never `26m`.
+- App/MenuBar focus state stays consistent after reopen.
+- MenuBar `End Deep Focus` requires passphrase and rejects invalid input.
+- MenuBar `Open TodoFocus` restores/opens a normal main window experience.
+- MenuBar panel displays current Deep Focus task title when available.

--- a/docs/superpowers/prs/2026-03-29-fix-81-menubar-focus-sync-passphrase-window.md
+++ b/docs/superpowers/prs/2026-03-29-fix-81-menubar-focus-sync-passphrase-window.md
@@ -1,0 +1,48 @@
+## Summary
+Closes #81.
+
+Fixes five MenuBar Deep Focus issues:
+- Quit path did not consistently clean up focus sessions.
+- 25-minute session could display as 26m.
+- End from MenuBar did not require passphrase.
+- Open from MenuBar could produce undesirable full-screen-style behavior.
+- MenuBar panel did not show current focus task.
+
+## Root Cause
+- No app-level termination hook to unify focus shutdown behavior.
+- Minute formatting used `ceil` without clamping negative elapsed time when `now` was slightly earlier than session start.
+- MenuBar end action directly called emergency-style end flow without passphrase gate.
+- Open action always used `openWindow` directly.
+- MenuBar UI lacked task-title context binding.
+
+## What Changed
+- `TodoAppStore`:
+  - Added `endDeepFocusWithPassphrase(_:)`.
+  - Added `endFocusForAppTermination()`.
+- `TodoFocusMacApp`:
+  - Added `NSApplicationDelegate` terminate hook to run focus cleanup before quit.
+  - Set a stable default main window size.
+- `DeepFocusMenuBarState`:
+  - Clamped elapsed time lower bound to avoid 26m at start.
+- `DeepFocusMenuBarPanel`:
+  - Added passphrase prompt for MenuBar end flow.
+  - Added inline invalid passphrase feedback.
+  - `Open TodoFocus` now prioritizes restoring existing main window.
+  - Added current focus task title display.
+- Tests:
+  - Added off-by-one boundary test for MenuBar countdown.
+  - Added passphrase-required end-flow and termination cleanup tests.
+
+## Verification
+```bash
+cd macos/TodoFocusMac
+xcodegen generate
+xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:CoreTests/DeepFocusMenuBarStateTests -only-testing:CoreTests/TodoAppStoreTests
+xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
+xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
+```
+
+Results:
+- Targeted tests succeeded.
+- Full tests succeeded.
+- Release build succeeded.

--- a/macos/TodoFocusMac/Sources/App/TodoAppStore.swift
+++ b/macos/TodoFocusMac/Sources/App/TodoAppStore.swift
@@ -317,6 +317,33 @@ final class TodoAppStore {
         return report
     }
 
+    func endDeepFocusWithPassphrase(_ passphrase: String) async throws -> DeepFocusReport? {
+        if hardFocusManager.isEnforcing {
+            try await hardFocusManager.endSession(passphrase: passphrase)
+        }
+
+        guard let report = appModel.deepFocusService.endSession() else {
+            return nil
+        }
+
+        if let focusTaskId = report.focusTaskId {
+            try? updateFocusTime(todoId: focusTaskId, additionalSeconds: Int(report.duration))
+        }
+
+        return report
+    }
+
+    func endFocusForAppTermination() async {
+        if appModel.deepFocusService.isActive {
+            _ = await endDeepFocus(endedByHardFocus: true)
+            return
+        }
+
+        if hardFocusManager.isEnforcing {
+            try? await hardFocusManager.emergencyEndSession()
+        }
+    }
+
     func updateFocusTime(todoId: String, additionalSeconds: Int) throws {
         guard let current = try todoRepository.fetchTodo(id: todoId) else {
             return

--- a/macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift
+++ b/macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift
@@ -10,6 +10,10 @@ struct DeepFocusMenuBarPanel: View {
     @Environment(\.openWindow) private var openWindow
     @State private var themeTokens: ThemeTokens
     @State private var now: Date = .now
+    @State private var endFocusPassphrase: String = ""
+    @State private var showEndFocusPrompt: Bool = false
+    @State private var passphraseError: String?
+    @FocusState private var isPassphraseFieldFocused: Bool
 
     init(store: TodoAppStore, themeStore: ThemeStore, mainWindowID: String) {
         self._store = Bindable(store)
@@ -36,8 +40,7 @@ struct DeepFocusMenuBarPanel: View {
                     isDestructive: false,
                     isDisabled: false
                 ) {
-                    openWindow(id: mainWindowID)
-                    NSApp.activate(ignoringOtherApps: true)
+                    openMainWindow()
                 }
 
                 MenuBarPanelActionButton(
@@ -46,8 +49,10 @@ struct DeepFocusMenuBarPanel: View {
                     isDestructive: true,
                     isDisabled: !state.isActive
                 ) {
-                    Task { @MainActor in
-                        _ = await store.endDeepFocus()
+                    passphraseError = nil
+                    showEndFocusPrompt.toggle()
+                    if showEndFocusPrompt {
+                        isPassphraseFieldFocused = true
                     }
                 }
 
@@ -60,9 +65,13 @@ struct DeepFocusMenuBarPanel: View {
                     NSApplication.shared.terminate(nil)
                 }
             }
+
+            if showEndFocusPrompt && state.isActive {
+                endFocusPrompt
+            }
         }
         .padding(14)
-        .frame(width: 320)
+        .frame(width: 340)
         .background(themeTokens.panelBackground)
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .overlay {
@@ -79,6 +88,13 @@ struct DeepFocusMenuBarPanel: View {
         }
         .onChange(of: themeStore.theme) { _, newTheme in
             themeTokens = ThemeTokens(theme: newTheme)
+        }
+        .onChange(of: state.isActive) { _, isActive in
+            if !isActive {
+                showEndFocusPrompt = false
+                passphraseError = nil
+                endFocusPassphrase = ""
+            }
         }
     }
 
@@ -119,12 +135,18 @@ struct DeepFocusMenuBarPanel: View {
 
     @ViewBuilder
     private func contextSection(state: DeepFocusMenuBarState, blockedAppCount: Int) -> some View {
-        HStack(spacing: 8) {
-            contextChip(title: "Blocked", value: "\(blockedAppCount) apps")
-            contextChip(
-                title: "Session",
-                value: state.menuBarBadge.map { "\($0) left" } ?? (state.isActive ? "Running" : "Idle")
-            )
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                contextChip(title: "Blocked", value: "\(blockedAppCount) apps")
+                contextChip(
+                    title: "Session",
+                    value: state.menuBarBadge.map { "\($0) left" } ?? (state.isActive ? "Running" : "Idle")
+                )
+            }
+
+            if state.isActive, let title = currentFocusTaskTitle, !title.isEmpty {
+                contextChip(title: "Task", value: title)
+            }
         }
     }
 
@@ -148,6 +170,106 @@ struct DeepFocusMenuBarPanel: View {
             RoundedRectangle(cornerRadius: 10)
                 .stroke(themeTokens.sectionBorder, lineWidth: 1)
         }
+    }
+
+    @ViewBuilder
+    private var endFocusPrompt: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Enter passphrase to end focus")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(themeTokens.textPrimary)
+
+            HStack(spacing: 8) {
+                SecureField("Passphrase", text: $endFocusPassphrase)
+                    .textFieldStyle(.plain)
+                    .focused($isPassphraseFieldFocused)
+                    .padding(.horizontal, 10)
+                    .frame(height: 34)
+                    .background(themeTokens.bgFloating, in: RoundedRectangle(cornerRadius: 8))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(themeTokens.sectionBorder, lineWidth: 1)
+                    }
+                    .onSubmit {
+                        submitEndFocus()
+                    }
+
+                Button("End") {
+                    submitEndFocus()
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 10)
+                .frame(height: 34)
+                .background(themeTokens.accentTerracotta.opacity(0.22), in: RoundedRectangle(cornerRadius: 8))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(themeTokens.accentTerracotta.opacity(0.55), lineWidth: 1)
+                }
+                .foregroundStyle(themeTokens.textPrimary)
+                .disabled(endFocusPassphrase.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+
+            if let passphraseError {
+                Text(passphraseError)
+                    .font(.system(size: 11))
+                    .foregroundStyle(themeTokens.danger)
+            }
+        }
+        .padding(10)
+        .background(themeTokens.bgFloating.opacity(0.85), in: RoundedRectangle(cornerRadius: 10))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(themeTokens.sectionBorder, lineWidth: 1)
+        }
+        .transition(.opacity.combined(with: .move(edge: .top)))
+        .animation(MotionTokens.focusEase, value: passphraseError ?? "")
+    }
+
+    private var currentFocusTaskTitle: String? {
+        guard let focusTaskId = store.deepFocusService.currentFocusTaskId else {
+            return nil
+        }
+        return store.todos.first(where: { $0.id == focusTaskId })?.title
+    }
+
+    private func submitEndFocus() {
+        let trimmed = endFocusPassphrase.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return
+        }
+
+        Task { @MainActor in
+            do {
+                _ = try await store.endDeepFocusWithPassphrase(trimmed)
+                showEndFocusPrompt = false
+                passphraseError = nil
+                endFocusPassphrase = ""
+            } catch let error as HardFocusError {
+                if error == .invalidPassphrase {
+                    passphraseError = "Invalid passphrase"
+                } else {
+                    passphraseError = "Unable to end focus right now"
+                }
+                isPassphraseFieldFocused = true
+            } catch {
+                passphraseError = "Unable to end focus right now"
+                isPassphraseFieldFocused = true
+            }
+        }
+    }
+
+    private func openMainWindow() {
+        NSApp.activate(ignoringOtherApps: true)
+
+        if let existingWindow = NSApp.windows.first(where: { $0.canBecomeMain }) {
+            if existingWindow.isMiniaturized {
+                existingWindow.deminiaturize(nil)
+            }
+            existingWindow.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        openWindow(id: mainWindowID)
     }
 }
 

--- a/macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarState.swift
+++ b/macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarState.swift
@@ -22,7 +22,7 @@ struct DeepFocusMenuBarState: Equatable {
         }
 
         if let sessionDuration, let sessionStartedAt {
-            let elapsed = now.timeIntervalSince(sessionStartedAt)
+            let elapsed = max(0, now.timeIntervalSince(sessionStartedAt))
             let remainingSeconds = max(0, sessionDuration - elapsed)
             let remainingMinutes = Int(ceil(remainingSeconds / 60.0))
             let remaining = "\(remainingMinutes)m"

--- a/macos/TodoFocusMac/Sources/TodoFocusMacApp.swift
+++ b/macos/TodoFocusMac/Sources/TodoFocusMacApp.swift
@@ -1,11 +1,36 @@
 import SwiftUI
+import AppKit
 
 private enum SceneIDs {
     static let mainWindow = "main"
 }
 
+final class TodoFocusMacAppDelegate: NSObject, NSApplicationDelegate {
+    var onTerminateRequested: (@MainActor () async -> Void)?
+    private var isHandlingTermination = false
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard !isHandlingTermination else {
+            return .terminateNow
+        }
+
+        guard let onTerminateRequested else {
+            return .terminateNow
+        }
+
+        isHandlingTermination = true
+        Task { @MainActor in
+            await onTerminateRequested()
+            NSApp.reply(toApplicationShouldTerminate: true)
+            self.isHandlingTermination = false
+        }
+        return .terminateLater
+    }
+}
+
 @main
 struct TodoFocusMacApp: App {
+    @NSApplicationDelegateAdaptor(TodoFocusMacAppDelegate.self) private var appDelegate
     @State private var appModel = AppModel()
     @State private var themeStore = ThemeStore()
     @State private var store: TodoAppStore?
@@ -53,6 +78,11 @@ struct TodoFocusMacApp: App {
                     )
                     .preferredColorScheme(themeStore.preferredColorScheme)
                     .themeMode(themeStore.theme)
+                    .task {
+                        appDelegate.onTerminateRequested = { [weak store] in
+                            await store?.endFocusForAppTermination()
+                        }
+                    }
                 } else {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Database unavailable")
@@ -69,6 +99,7 @@ struct TodoFocusMacApp: App {
         }
         .windowStyle(.hiddenTitleBar)
         .windowToolbarStyle(.unified(showsTitle: false))
+        .defaultSize(width: 1280, height: 820)
 
         MenuBarExtra {
             Group {

--- a/macos/TodoFocusMac/Tests/CoreTests/DeepFocusMenuBarStateTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/DeepFocusMenuBarStateTests.swift
@@ -49,4 +49,19 @@ final class DeepFocusMenuBarStateTests: XCTestCase {
         XCTAssertEqual(state.menuBarBadge, "0m")
         XCTAssertTrue(state.isActive)
     }
+
+    func testFromTimedSessionDoesNotExceedConfiguredMinutesWhenNowSlightlyBeforeStart() {
+        let sessionStartedAt = Date(timeIntervalSince1970: 1_000)
+        let now = Date(timeIntervalSince1970: 999.7)
+
+        let state = DeepFocusMenuBarState.from(
+            isActive: true,
+            sessionDuration: 25 * 60,
+            sessionStartedAt: sessionStartedAt,
+            now: now
+        )
+
+        XCTAssertEqual(state.menuBarBadge, "25m")
+        XCTAssertEqual(state.subtitle, "25m remaining")
+    }
 }

--- a/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift
@@ -143,6 +143,112 @@ final class TodoAppStoreTests: XCTestCase {
         XCTAssertTrue(persisted.isCompleted)
     }
 
+    @MainActor
+    func testEndDeepFocusWithPassphraseRejectsInvalidPassphraseAndKeepsSessionActive() async throws {
+        let path = NSTemporaryDirectory() + UUID().uuidString + ".sqlite"
+        let manager = try DatabaseManager(databasePath: path)
+        let listRepository = ListRepository(dbQueue: manager.dbQueue)
+        let todoRepository = TodoRepository(dbQueue: manager.dbQueue)
+        let stepRepository = StepRepository(dbQueue: manager.dbQueue)
+        let hardFocusRepository = HardFocusSessionRepository(dbQueue: manager.dbQueue)
+        let appModel = AppModel()
+        let hardFocusManager = HardFocusSessionManager(
+            repository: hardFocusRepository,
+            agentManager: MockTestHardFocusAgentManager(isRegistered: true, isRunning: true),
+            inProcessEnforcer: MockTestHardFocusInProcessEnforcer(),
+            isAccessibilityTrusted: { true },
+            agentStartupTimeout: 0,
+            agentPollInterval: 0.01
+        )
+
+        let store = TodoAppStore(
+            appModel: appModel,
+            listRepository: listRepository,
+            todoRepository: todoRepository,
+            stepRepository: stepRepository,
+            hardFocusRepository: hardFocusRepository,
+            hardFocusManager: hardFocusManager,
+            now: Date.init
+        )
+
+        let todo = try store.quickAdd(
+            title: "Needs passphrase",
+            planned: false,
+            isImportant: false,
+            isMyDay: false,
+            list: nil
+        )
+
+        store.startDeepFocus(
+            blockedApps: ["com.apple.Safari"],
+            duration: nil,
+            focusTaskId: todo.id,
+            passphrase: "unlock"
+        )
+
+        let started = expectation(description: "Hard focus started")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            if hardFocusManager.isEnforcing {
+                started.fulfill()
+            }
+        }
+        await fulfillment(of: [started], timeout: 1.0)
+
+        do {
+            _ = try await store.endDeepFocusWithPassphrase("wrong-passphrase")
+            XCTFail("Expected invalid passphrase error")
+        } catch let error as HardFocusError {
+            XCTAssertEqual(error, .invalidPassphrase)
+        }
+
+        XCTAssertTrue(hardFocusManager.isEnforcing)
+        XCTAssertTrue(store.deepFocusService.isActive)
+    }
+
+    @MainActor
+    func testEndFocusForAppTerminationStopsHardFocusEvenWhenDeepFocusIsInactive() async throws {
+        let path = NSTemporaryDirectory() + UUID().uuidString + ".sqlite"
+        let manager = try DatabaseManager(databasePath: path)
+        let listRepository = ListRepository(dbQueue: manager.dbQueue)
+        let todoRepository = TodoRepository(dbQueue: manager.dbQueue)
+        let stepRepository = StepRepository(dbQueue: manager.dbQueue)
+        let hardFocusRepository = HardFocusSessionRepository(dbQueue: manager.dbQueue)
+        let appModel = AppModel()
+        let hardFocusManager = HardFocusSessionManager(
+            repository: hardFocusRepository,
+            agentManager: MockTestHardFocusAgentManager(isRegistered: true, isRunning: true),
+            inProcessEnforcer: MockTestHardFocusInProcessEnforcer(),
+            isAccessibilityTrusted: { true },
+            agentStartupTimeout: 0,
+            agentPollInterval: 0.01
+        )
+
+        let store = TodoAppStore(
+            appModel: appModel,
+            listRepository: listRepository,
+            todoRepository: todoRepository,
+            stepRepository: stepRepository,
+            hardFocusRepository: hardFocusRepository,
+            hardFocusManager: hardFocusManager,
+            now: Date.init
+        )
+
+        try await hardFocusManager.startSession(
+            blockedApps: ["com.apple.Safari"],
+            duration: nil,
+            focusTaskId: nil,
+            passphrase: "unlock"
+        )
+        XCTAssertTrue(hardFocusManager.isEnforcing)
+        XCTAssertFalse(store.deepFocusService.isActive)
+
+        await store.endFocusForAppTermination()
+
+        XCTAssertFalse(hardFocusManager.isEnforcing)
+        XCTAssertFalse(store.deepFocusService.isActive)
+        XCTAssertNil(try hardFocusRepository.activeSession())
+    }
+
     func testVisibleTodosUsesAppModelSelectionAndTimeFilter() throws {
         let now = Date(timeIntervalSince1970: 1_763_520_000)
         let tomorrow = now.addingTimeInterval(86_400)


### PR DESCRIPTION
## Summary
Closes #81.

Fixes five MenuBar Deep Focus issues:
- Quit path did not consistently clean up focus sessions.
- 25-minute session could display as 26m.
- End from MenuBar did not require passphrase.
- Open from MenuBar could produce undesirable full-screen-style behavior.
- MenuBar panel did not show current focus task.

## Root Cause
- No app-level termination hook to unify focus shutdown behavior.
- Minute formatting used `ceil` without clamping negative elapsed time when `now` was slightly earlier than session start.
- MenuBar end action directly called emergency-style end flow without passphrase gate.
- Open action always used `openWindow` directly.
- MenuBar UI lacked task-title context binding.

## What Changed
- `TodoAppStore`:
  - Added `endDeepFocusWithPassphrase(_:)`.
  - Added `endFocusForAppTermination()`.
- `TodoFocusMacApp`:
  - Added `NSApplicationDelegate` terminate hook to run focus cleanup before quit.
  - Set a stable default main window size.
- `DeepFocusMenuBarState`:
  - Clamped elapsed time lower bound to avoid 26m at start.
- `DeepFocusMenuBarPanel`:
  - Added passphrase prompt for MenuBar end flow.
  - Added inline invalid passphrase feedback.
  - `Open TodoFocus` now prioritizes restoring existing main window.
  - Added current focus task title display.
- Tests:
  - Added off-by-one boundary test for MenuBar countdown.
  - Added passphrase-required end-flow and termination cleanup tests.

## Verification
```bash
cd macos/TodoFocusMac
xcodegen generate
xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:CoreTests/DeepFocusMenuBarStateTests -only-testing:CoreTests/TodoAppStoreTests
xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
```

Results:
- Targeted tests succeeded.
- Full tests succeeded.
- Release build succeeded.
