### PR TITLE
fix: polish notes editor UI and internal scrolling

### DIFF
--- a/docs/superpowers/issues/2026-03-29-notes-editor-polish-and-scroll.md
+++ b/docs/superpowers/issues/2026-03-29-notes-editor-polish-and-scroll.md
@@ -1,0 +1,29 @@
+# UI Polish: Notes Editor Styling + Scroll Behavior
+
+## Summary
+Improve Task Detail Notes input appearance and interaction quality, and enforce clearer scroll behavior for long content.
+
+## Scope
+1. Refine visual style of Notes editor surface (padding, border, focus, hierarchy).
+2. Make Notes area fixed-height with internal vertical scrolling for long content.
+3. Preserve existing note saving behavior (`updateNotesDebounced`).
+
+## Repro
+- Open Task Detail panel.
+- Look at Notes input surface.
+- Current Notes field appears visually rough and not aligned with newer polished controls.
+
+## Expected
+- Notes field matches current TodoFocus dark design language.
+- Focus state is clear but subtle.
+- Notes area uses fixed viewport and scrolls internally when content exceeds height.
+
+## Constraints
+- No behavior changes to data model/debounce update logic.
+- Reuse `ThemeTokens` and `MotionTokens`.
+- Keep changes focused in Task Detail UI.
+
+## Acceptance Criteria
+- Notes editor looks polished and consistent with app UI.
+- Long notes scroll inside the editor viewport.
+- Build/tests pass.

--- a/docs/superpowers/plans/2026-03-29-notes-editor-polish-and-scroll-plan.md
+++ b/docs/superpowers/plans/2026-03-29-notes-editor-polish-and-scroll-plan.md
@@ -1,0 +1,16 @@
+# Notes Editor Polish + Scroll Plan
+
+## Goal
+Upgrade Task Detail Notes editor UX and visual quality while preserving persistence behavior.
+
+## Files
+- Modify: `macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift`
+- Create: `docs/superpowers/prs/2026-03-29-fix-<issue>-notes-editor-polish-and-scroll.md`
+
+## Steps
+1. Redesign Notes section container using existing tokens and consistent corner/border treatment.
+2. Add explicit focus state for Notes input.
+3. Set fixed editor height and internal scrolling behavior for long content.
+4. Keep `store.updateNotesDebounced` unchanged.
+5. Run verification gates (`xcodegen`, test, release build).
+6. Write PR markdown with verification outcomes.

--- a/docs/superpowers/prs/2026-03-29-fix-86-notes-editor-polish-and-scroll.md
+++ b/docs/superpowers/prs/2026-03-29-fix-86-notes-editor-polish-and-scroll.md
@@ -1,0 +1,36 @@
+## Summary
+Closes #86.
+
+Polishes the Task Detail Notes input and enforces explicit internal scrolling behavior:
+- Notes field now uses a cleaner themed surface with stronger hierarchy.
+- Focus state is clearer (border + glow) but still subtle.
+- Notes editor now has a fixed viewport height and scrolls internally for long content.
+
+## What Changed
+- Updated `macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift`
+  - Added `@FocusState private var isNotesFocused` for Notes focus styling.
+  - Redesigned `notesSection` with:
+    - header row (`Notes` + `Scrollable` hint)
+    - contextual empty placeholder text
+    - fixed `TextEditor` height (`170`) for consistent internal scrolling
+    - themed container using existing tokens (`inputSurface`, `inputBorder`, `inputBorderFocused`, `inputGlow`)
+    - subtle shadow and animated focus affordance via `MotionTokens.focusEase`
+  - Kept existing debounced save path unchanged:
+    - `store.updateNotesDebounced(todoId:notes:)`
+
+## Why
+The previous Notes editor looked visually rough and less cohesive than the rest of the polished Task Detail controls. The new treatment aligns with current input styling and makes long-note behavior explicit and predictable.
+
+## Verification
+```bash
+cd macos/TodoFocusMac
+xcodegen generate
+
+xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
+
+xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
+```
+
+Results:
+- `** TEST SUCCEEDED **`
+- `** BUILD SUCCEEDED **`

--- a/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
@@ -11,6 +11,7 @@ struct TaskDetailView: View {
     @State private var titleText: String = ""
     @State private var titleValidationMessage: String?
     @FocusState private var isTitleFocused: Bool
+    @FocusState private var isNotesFocused: Bool
     @State private var showDeepFocusSheet = false
     @State private var showFocusReport = false
     @State private var focusReport: DeepFocusReport?
@@ -271,20 +272,51 @@ struct TaskDetailView: View {
     }
 
     private func notesSection(todo: Todo) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Notes")
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(tokens.mutedText)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Notes")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(tokens.mutedText)
+                Spacer()
+                Text("Scrollable")
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(tokens.textTertiary)
+            }
 
-            TextEditor(text: $notesText)
-                .frame(minHeight: 100)
-                .scrollContentBackground(.hidden)
-                .padding(10)
-                .background(tokens.bgFloating, in: RoundedRectangle(cornerRadius: 8))
-                .foregroundStyle(tokens.textPrimary)
-                .onChange(of: notesText) { _, newValue in
-                    store.updateNotesDebounced(todoId: todo.id, notes: newValue)
+            ZStack(alignment: .topLeading) {
+                if notesText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text("Capture thoughts, context, and follow-ups...")
+                        .font(.subheadline)
+                        .foregroundStyle(tokens.textTertiary)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 12)
+                        .allowsHitTesting(false)
                 }
+
+                TextEditor(text: $notesText)
+                    .focused($isNotesFocused)
+                    .frame(height: 170)
+                    .scrollContentBackground(.hidden)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                    .foregroundStyle(tokens.textPrimary)
+                    .onChange(of: notesText) { _, newValue in
+                        store.updateNotesDebounced(todoId: todo.id, notes: newValue)
+                    }
+            }
+            .background(tokens.inputSurface, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(isNotesFocused ? tokens.inputBorderFocused : tokens.inputBorder, lineWidth: isNotesFocused ? 1.2 : 1)
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(tokens.inputGlow.opacity(isNotesFocused ? 0.52 : 0), lineWidth: 4)
+                    .blur(radius: 0.7)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .shadow(color: Color.black.opacity(0.12), radius: 5, y: 2)
+            .animation(MotionTokens.focusEase, value: isNotesFocused)
         }
     }
 


### PR DESCRIPTION
## Summary
Closes #86.

Polishes the Task Detail Notes input and enforces explicit internal scrolling behavior:
- Notes field now uses a cleaner themed surface with stronger hierarchy.
- Focus state is clearer (border + glow) but still subtle.
- Notes editor now has a fixed viewport height and scrolls internally for long content.

## What Changed
- Updated `macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift`
  - Added `@FocusState private var isNotesFocused` for Notes focus styling.
  - Redesigned `notesSection` with:
    - header row (`Notes` + `Scrollable` hint)
    - contextual empty placeholder text
    - fixed `TextEditor` height (`170`) for consistent internal scrolling
    - themed container using existing tokens (`inputSurface`, `inputBorder`, `inputBorderFocused`, `inputGlow`)
    - subtle shadow and animated focus affordance via `MotionTokens.focusEase`
  - Kept existing debounced save path unchanged:
    - `store.updateNotesDebounced(todoId:notes:)`

## Why
The previous Notes editor looked visually rough and less cohesive than the rest of the polished Task Detail controls. The new treatment aligns with current input styling and makes long-note behavior explicit and predictable.

## Verification
```bash
cd macos/TodoFocusMac
xcodegen generate

xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"

xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
```

Results:
- `** TEST SUCCEEDED **`
- `** BUILD SUCCEEDED **`
