### PR TITLE
Fix portable import/export (URL-only) and polish Settings UX

### DIFF
--- a/docs/superpowers/issues/2026-03-30-portable-import-export-url-only.md
+++ b/docs/superpowers/issues/2026-03-30-portable-import-export-url-only.md
@@ -1,0 +1,27 @@
+# Portable Import/Export: URL-Only Launch Resources + Settings UX Polish
+
+## Problem
+Current import/export behavior was not aligned with cross-device portability expectations. Launch resources tied to local filesystem/app paths (`file`, `app`) are not portable between devices, and the Settings import/export section needed clearer UX and messaging.
+
+## Goals
+- Export/import only portable launch resources (`url`).
+- Skip non-portable launch resources (`file`, `app`) during import and report skipped counts.
+- Show preflight warning when non-portable launch resources are present.
+- Improve Settings import/export UI clarity and visual quality.
+- Add explicit reminder in UI that file/app resources are intentionally excluded for portability.
+
+## Scope
+- Data export/import logic in `ExportService`.
+- Export format version update and compatibility handling.
+- Data tests covering URL-only behavior and non-portable skip semantics.
+- SettingsView import/export redesign and updated copy.
+
+## Acceptance Criteria
+- Export payload includes only URL launch resources.
+- Import persists only URL launch resources and skips file/app entries without failing import.
+- Preflight surfaces warning for non-portable launch resources.
+- Full test suite passes and Release build succeeds.
+- Settings view clearly communicates portability behavior.
+
+## Notes
+- Device-local state remains excluded from import/export (theme, window persistence, deep focus runtime/session state, etc.).

--- a/docs/superpowers/plans/2026-03-30-portable-import-export-and-settings-polish.md
+++ b/docs/superpowers/plans/2026-03-30-portable-import-export-and-settings-polish.md
@@ -1,0 +1,52 @@
+# Portable Import/Export + Settings UI Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure import/export is portable across devices by transferring only portable data (lists/todos/steps and URL launch resources), and improve Settings import/export UX to be cleaner and more graceful.
+
+**Architecture:** Keep `ExportService` as the single source of truth for payload filtering and import behavior. Add explicit portability hints to export metadata and import preflight messaging. Refresh `SettingsView` with token-based surfaces and clearer copy that explains portability limits.
+
+**Tech Stack:** SwiftUI, Swift 6, GRDB, XCTest.
+
+---
+
+## Chunk 1: Portable Data Rules
+
+### Task 1: Export/import URL launch resources only
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Sources/Data/Export/ExportService.swift`
+- Modify: `macos/TodoFocusMac/Sources/Data/Export/ExportModels.swift`
+- Test: `macos/TodoFocusMac/Tests/DataTests/ExportServiceTests.swift`
+
+- [ ] **Step 1: Add failing tests** for non-URL launch resources excluded from export and skipped on import.
+- [ ] **Step 2: Implement filtering** so export emits only `.url` resources.
+- [ ] **Step 3: Implement import guard** to accept only `.url`, increment skipped count for `.file`/`.app`.
+- [ ] **Step 4: Add portability hint** in export metadata and preflight warning.
+- [ ] **Step 5: Run targeted tests** for `ExportServiceTests` and ensure they pass.
+
+## Chunk 2: Settings UX Polish + Reminder
+
+### Task 2: Improve import/export panel look and clarity
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Sources/Features/Settings/SettingsView.swift`
+
+- [ ] **Step 1: Restructure UI** into cleaner grouped cards/sections with stronger hierarchy.
+- [ ] **Step 2: Improve controls** for Import Mode and action buttons (consistent style and spacing).
+- [ ] **Step 3: Add explicit reminder text** that only URL launch resources are portable; file/app resources are intentionally skipped.
+- [ ] **Step 4: Improve confirmation and success text** to reflect portability behavior.
+
+## Chunk 3: Verification
+
+### Task 3: Run regression checks
+
+**Files:**
+- Test: `macos/TodoFocusMac/Tests/DataTests/ExportServiceTests.swift`
+- Verify build: `macos/TodoFocusMac`
+
+- [ ] **Step 1:** `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:DataTests/ExportServiceTests`
+- [ ] **Step 2:** `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+- [ ] **Step 3:** `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+
+Plan complete and saved to `docs/superpowers/plans/2026-03-30-portable-import-export-and-settings-polish.md`.

--- a/docs/superpowers/prs/2026-03-30-portable-import-export-url-only.md
+++ b/docs/superpowers/prs/2026-03-30-portable-import-export-url-only.md
@@ -1,0 +1,24 @@
+## Summary
+- make import/export portable by keeping launch resources URL-only
+- skip non-portable launch resources (`file`, `app`) during import with explicit preflight warning and skip counts
+- refresh Settings import/export section with cleaner card-style UI and explicit portability reminder
+- bump export format to `1.2` while keeping support for `1.0` and `1.1`
+
+## Linked Issue
+Closes #88
+
+## Changes
+- `ExportService` now filters launch resources on export to `.url` only
+- `ExportService` import now ignores non-URL launch resources and increments skipped counters
+- preflight warning now calls out non-portable launch resources when present
+- export metadata includes portability hints
+- Settings view now has clearer grouped sections and messaging around portability constraints
+- added/updated tests for URL-only behavior and non-portable skip semantics
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:DataTests/ExportServiceTests`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`

--- a/macos/TodoFocusMac/Sources/Data/Export/ExportModels.swift
+++ b/macos/TodoFocusMac/Sources/Data/Export/ExportModels.swift
@@ -3,10 +3,11 @@ import Foundation
 enum ExportFormatVersion {
     static let v1_0 = "1.0"
     static let v1_1 = "1.1"
-    static let current = v1_1
+    static let v1_2 = "1.2"
+    static let current = v1_2
 
     static func isSupported(_ version: String) -> Bool {
-        version == v1_0 || version == v1_1
+        version == v1_0 || version == v1_1 || version == v1_2
     }
 }
 

--- a/macos/TodoFocusMac/Sources/Data/Export/ExportService.swift
+++ b/macos/TodoFocusMac/Sources/Data/Export/ExportService.swift
@@ -90,6 +90,7 @@ final class ExportService {
                     }
 
                 let resources = (try? decodeLaunchResources(record.launchResources)) ?? []
+                let portableResources = resources.filter { $0.type == .url }
 
                 return ExportTodo(
                     id: record.id,
@@ -105,7 +106,7 @@ final class ExportService {
                     recurrenceInterval: record.recurrenceInterval,
                     sortOrder: record.sortOrder,
                     steps: steps,
-                    launchResources: resources.map { ExportLaunchResource(type: $0.type.rawValue, value: $0.value, label: $0.label) }
+                    launchResources: portableResources.map { ExportLaunchResource(type: $0.type.rawValue, value: $0.value, label: $0.label) }
                 )
             }
         }
@@ -116,7 +117,12 @@ final class ExportService {
             meta: ExportMeta(
                 appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
                 platform: "macOS",
-                importHints: ["supportsModes:replace,merge", "backupBeforeReplace:true"]
+                importHints: [
+                    "supportsModes:replace,merge",
+                    "backupBeforeReplace:true",
+                    "portableLaunchResources:urlOnly",
+                    "deviceLocalStateExcluded:true"
+                ]
             ),
             lists: lists,
             todos: todos
@@ -152,6 +158,13 @@ final class ExportService {
 
         if importData.lists.isEmpty && importData.todos.isEmpty {
             warnings.append("Import file contains no lists or todos")
+        }
+
+        let nonPortableLaunchResourceCount = importData.todos.reduce(0) { partial, todo in
+            partial + todo.launchResources.filter { $0.type != LaunchResourceType.url.rawValue }.count
+        }
+        if nonPortableLaunchResourceCount > 0 {
+            warnings.append("Found \(nonPortableLaunchResourceCount) non-portable launch resources (file/app). They will be skipped.")
         }
 
         let launchResourceCount = importData.todos.reduce(0) { $0 + $1.launchResources.count }
@@ -271,6 +284,10 @@ final class ExportService {
                     guard let type = LaunchResourceType(rawValue: er.type) else {
                         report.skipped.launchResources += 1
                         report.errors.append("Unsupported launch resource type '\(er.type)' for todo \(todo.id)")
+                        return nil
+                    }
+                    guard type == .url else {
+                        report.skipped.launchResources += 1
                         return nil
                     }
                     return LaunchResource(

--- a/macos/TodoFocusMac/Sources/Features/Settings/SettingsView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Settings/SettingsView.swift
@@ -40,7 +40,7 @@ struct SettingsView: View {
                 Label("General", systemImage: "gear")
             }
         }
-        .frame(maxWidth: 450, maxHeight: 300)
+        .frame(maxWidth: 520, maxHeight: 430)
     }
 
     private func performExport() {
@@ -122,7 +122,7 @@ struct SettingsView: View {
             lines.append("Created — Lists: \(report.created.lists), Todos: \(report.created.todos), Steps: \(report.created.steps)")
             lines.append("Updated — Lists: \(report.updated.lists), Todos: \(report.updated.todos), Steps: \(report.updated.steps)")
             if report.skipped.launchResources > 0 {
-                lines.append("Skipped launch resources: \(report.skipped.launchResources)")
+                lines.append("Skipped non-portable launch resources (file/app): \(report.skipped.launchResources)")
             }
             if let backup = report.backupFilePath {
                 lines.append("Backup saved to: \(backup)")
@@ -154,54 +154,67 @@ struct GeneralSettingsView: View {
     @Binding var importError: String?
     @Binding var importSuccessMessage: String
     @Binding var pendingImportPreflight: ImportPreflightResult?
+    @Environment(\.themeTokens) private var tokens
 
     var body: some View {
-        Form {
-            Section("Appearance") {
-                Picker("Theme", selection: $themeStore.theme) {
-                    Text("Dark").tag(ThemeStore.Theme.dark)
-                    Text("Light").tag(ThemeStore.Theme.light)
-                    Text("System").tag(ThemeStore.Theme.system)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                settingsCard(title: "Appearance", icon: "paintbrush") {
+                    Picker("Theme", selection: $themeStore.theme) {
+                        Text("Dark").tag(ThemeStore.Theme.dark)
+                        Text("Light").tag(ThemeStore.Theme.light)
+                        Text("System").tag(ThemeStore.Theme.system)
+                    }
+                    .pickerStyle(.segmented)
                 }
-                .pickerStyle(.segmented)
-            }
 
-            Section {
-                Text("Data Management")
-                    .font(.headline)
-            }
+                settingsCard(title: "Data Import & Export", icon: "arrow.left.arrow.right.circle") {
+                    Text("Portable transfer: lists, tasks, steps, and URL launch resources.")
+                        .font(.caption)
+                        .foregroundStyle(tokens.textSecondary)
+                    Text("Reminder: file and app launch resources are device-local and are intentionally skipped during import/export.")
+                        .font(.caption)
+                        .foregroundStyle(tokens.warning)
+                        .padding(.bottom, 4)
 
-            Section {
-                Button("Export Data") {
-                    onExport()
-                }
-                .buttonStyle(.bordered)
+                    Picker("Import Mode", selection: $selectedImportMode) {
+                        ForEach(ImportMode.allCases) { mode in
+                            Text(mode.title).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.menu)
 
-                Picker("Import Mode", selection: $selectedImportMode) {
-                    ForEach(ImportMode.allCases) { mode in
-                        Text(mode.title).tag(mode)
+                    HStack(spacing: 10) {
+                        Button("Export Data") {
+                            onExport()
+                        }
+                        .buttonStyle(.borderedProminent)
+
+                        Button("Import Data") {
+                            onImport()
+                        }
+                        .buttonStyle(.bordered)
                     }
                 }
-                .pickerStyle(.menu)
 
-                Button("Import Data") {
-                    onImport()
+                settingsCard(title: "Database", icon: "internaldrive") {
+                    Text(URL(fileURLWithPath: databasePath).lastPathComponent)
+                        .font(.subheadline)
+                        .foregroundStyle(tokens.textPrimary)
+                    Text(databasePath)
+                        .font(.caption)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                        .foregroundStyle(tokens.textTertiary)
                 }
-                .buttonStyle(.bordered)
             }
-
-            Section {
-                Text("Database: \(URL(fileURLWithPath: databasePath).lastPathComponent)")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            .padding(16)
         }
-        .formStyle(.grouped)
-        .padding()
+        .background(tokens.bgBase)
         .alert("Export Successful", isPresented: $showExportSuccess) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("Your data has been exported successfully.")
+            Text("Portable data has been exported successfully.")
         }
         .alert("Export Failed", isPresented: $showExportError) {
             Button("OK", role: .cancel) {}
@@ -230,10 +243,31 @@ struct GeneralSettingsView: View {
         } message: {
             if let preflight = pendingImportPreflight {
                 let warningsText = preflight.warnings.isEmpty ? "None" : preflight.warnings.joined(separator: ", ")
-                Text("Version: \(preflight.version)\nLists: \(preflight.counts.lists), Todos: \(preflight.counts.todos), Steps: \(preflight.counts.steps)\nWarnings: \(warningsText)")
+                Text("Version: \(preflight.version)\nLists: \(preflight.counts.lists), Todos: \(preflight.counts.todos), Steps: \(preflight.counts.steps), Launch Resources: \(preflight.counts.launchResources)\nWarnings: \(warningsText)")
             } else {
                 Text("Proceed with import?")
             }
         }
+    }
+
+    @ViewBuilder
+    private func settingsCard<Content: View>(title: String, icon: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(tokens.accentTerracotta)
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(tokens.textPrimary)
+            }
+            content()
+        }
+        .padding(12)
+        .background(tokens.bgElevated, in: RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(tokens.sectionBorder, lineWidth: 1)
+        )
     }
 }

--- a/macos/TodoFocusMac/Tests/DataTests/ExportServiceTests.swift
+++ b/macos/TodoFocusMac/Tests/DataTests/ExportServiceTests.swift
@@ -31,6 +31,20 @@ final class ExportServiceTests: XCTestCase {
                     label: "Docs",
                     value: "https://example.com",
                     createdAt: Date()
+                ),
+                LaunchResource(
+                    id: "res-2",
+                    type: .file,
+                    label: "Spec",
+                    value: "/Users/example/spec.md",
+                    createdAt: Date()
+                ),
+                LaunchResource(
+                    id: "res-3",
+                    type: .app,
+                    label: "Safari",
+                    value: "/Applications/Safari.app",
+                    createdAt: Date()
                 )
             ]
             let resourcesData = try JSONEncoder().encode(resources)
@@ -98,6 +112,58 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertFalse(preflight.blockingErrors.isEmpty)
     }
 
+    func testExportIncludesOnlyURLLaunchResources() throws {
+        let manager = try makeManager()
+        try seedBasicData(manager)
+        let service = makeService(manager)
+
+        let data = try service.exportToJSON()
+        let payload = try ExportData.decode(from: data)
+        let todo = try XCTUnwrap(payload.todos.first { $0.id == "todo-1" })
+
+        XCTAssertEqual(todo.launchResources.count, 1)
+        XCTAssertEqual(todo.launchResources.first?.type, LaunchResourceType.url.rawValue)
+        XCTAssertEqual(todo.launchResources.first?.value, "https://example.com")
+    }
+
+    func testPreflightWarnsWhenNonPortableLaunchResourcesExist() throws {
+        let manager = try makeManager()
+        let service = makeService(manager)
+
+        let payload = """
+        {
+          "version": "1.2",
+          "exportedAt": "2026-03-30T12:00:00Z",
+          "lists": [],
+          "todos": [
+            {
+              "id": "todo-1",
+              "title": "Imported",
+              "isCompleted": false,
+              "isImportant": false,
+              "isMyDay": false,
+              "dueDate": null,
+              "notes": "",
+              "listId": null,
+              "focusTimeSeconds": 0,
+              "recurrence": null,
+              "recurrenceInterval": 1,
+              "sortOrder": 0,
+              "steps": [],
+              "launchResources": [
+                { "type": "url", "value": "https://example.com", "label": "Docs" },
+                { "type": "file", "value": "/tmp/spec.md", "label": "Spec" }
+              ]
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let preflight = try service.preflightImportJSON(payload)
+        XCTAssertEqual(preflight.counts.launchResources, 2)
+        XCTAssertTrue(preflight.warnings.contains(where: { $0.contains("non-portable launch resources") }))
+    }
+
     func testImportReplaceReturnsStructuredReport() throws {
         let manager = try makeManager()
         try seedBasicData(manager)
@@ -107,6 +173,53 @@ final class ExportServiceTests: XCTestCase {
         let report = try service.executeImportJSON(data, mode: .replace)
 
         XCTAssertGreaterThanOrEqual(report.created.todos, 1)
+    }
+
+    func testImportSkipsNonURLLaunchResources() throws {
+        let manager = try makeManager()
+        let service = makeService(manager)
+
+        let payload = """
+        {
+          "version": "1.2",
+          "exportedAt": "2026-03-30T12:00:00Z",
+          "lists": [
+            { "id": "list-1", "name": "Work", "color": "#C46849", "sortOrder": 0 }
+          ],
+          "todos": [
+            {
+              "id": "todo-1",
+              "title": "Imported",
+              "isCompleted": false,
+              "isImportant": false,
+              "isMyDay": false,
+              "dueDate": null,
+              "notes": "",
+              "listId": "list-1",
+              "focusTimeSeconds": 0,
+              "recurrence": null,
+              "recurrenceInterval": 1,
+              "sortOrder": 0,
+              "steps": [],
+              "launchResources": [
+                { "type": "url", "value": "https://example.com", "label": "Docs" },
+                { "type": "file", "value": "/tmp/spec.md", "label": "Spec" },
+                { "type": "app", "value": "/Applications/Safari.app", "label": "Safari" }
+              ]
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let report = try service.executeImportJSON(payload, mode: .replace)
+        XCTAssertEqual(report.created.launchResources, 1)
+        XCTAssertEqual(report.skipped.launchResources, 2)
+
+        let todoRepo = TodoRepository(dbQueue: manager.dbQueue)
+        let merged = try XCTUnwrap(todoRepo.fetchTodo(id: "todo-1"))
+        let decoded = try JSONDecoder().decode([LaunchResource].self, from: Data(merged.launchResources.utf8))
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.first?.type, .url)
     }
 
     func testReplaceImportCreatesBackupSnapshotBeforeMutation() throws {


### PR DESCRIPTION
## Summary
- make import/export portable by keeping launch resources URL-only
- skip non-portable launch resources (`file`, `app`) during import with explicit preflight warning and skip counts
- refresh Settings import/export section with cleaner card-style UI and explicit portability reminder
- bump export format to `1.2` while keeping support for `1.0` and `1.1`

## Linked Issue
Closes #88

## Changes
- `ExportService` now filters launch resources on export to `.url` only
- `ExportService` import now ignores non-URL launch resources and increments skipped counters
- preflight warning now calls out non-portable launch resources when present
- export metadata includes portability hints
- Settings view now has clearer grouped sections and messaging around portability constraints
- added/updated tests for URL-only behavior and non-portable skip semantics

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:DataTests/ExportServiceTests`
  - `** TEST SUCCEEDED **`
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`
