### PR TITLE
Add Quick Capture voice input MVP (zh+en)

### DIFF
--- a/docs/superpowers/issues/2026-03-30-quick-capture-voice-mvp.md
+++ b/docs/superpowers/issues/2026-03-30-quick-capture-voice-mvp.md
@@ -1,0 +1,28 @@
+# Quick Capture Voice Input MVP (Chinese + English)
+
+## Problem
+Quick Capture currently supports only typed input. Users want a fast voice option while preserving explicit confirmation before save.
+
+## Scope (MVP)
+- Add voice capture button in Quick Capture panel.
+- Click once to start recording/transcription, click again to stop.
+- Support Chinese + English speech recognition.
+- Recognized text overwrites the input field.
+- If permissions are denied, show guidance and keep manual text input available.
+- Keep existing save behavior: user must click `Add` to persist.
+
+## UX Requirements
+- UI should be polished and aligned with existing app visual style.
+- Clear recording status (idle/recording/error).
+- Permission-denied state provides a settings shortcut.
+
+## Non-Goals
+- No auto-save on stop.
+- No natural-language date parsing in this iteration.
+- No cloud STT integration.
+
+## Acceptance Criteria
+- User can record and transcribe via panel controls.
+- Permission denial does not block manual capture.
+- Existing keyboard shortcuts and capture flow remain intact.
+- Build and tests pass.

--- a/docs/superpowers/plans/2026-03-30-quick-capture-voice-mvp.md
+++ b/docs/superpowers/plans/2026-03-30-quick-capture-voice-mvp.md
@@ -1,0 +1,49 @@
+# Quick Capture Voice Input MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a polished voice-input option to Quick Capture with click-to-start/stop recording, bilingual (Chinese + English) transcription, overwrite behavior, and graceful permission fallback.
+
+**Architecture:** Extend `QuickCaptureService` with a speech-capture state machine and Speech/AVFoundation integration. Bind the panel input directly to service-owned draft text so speech results can update UI instantly. Keep persistence logic unchanged (`Add` confirms save).
+
+**Tech Stack:** SwiftUI, Observation, Speech framework, AVFoundation, macOS AppKit panel.
+
+---
+
+## Chunk 1: Voice Capture Core
+
+### Task 1: Add service-level speech state and lifecycle
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Sources/App/QuickCaptureService.swift`
+
+- [ ] **Step 1:** add state for draft text, recording state, permission status, and speech errors.
+- [ ] **Step 2:** integrate permission checks for speech + microphone with async requests.
+- [ ] **Step 3:** add start/stop/toggle voice capture APIs.
+- [ ] **Step 4:** implement bilingual recognition pipeline (`zh-CN` + `en-US`) and transcript selection.
+- [ ] **Step 5:** ensure cleanup stops audio/recognition tasks safely.
+
+## Chunk 2: Quick Capture UI Polish + Voice Controls
+
+### Task 2: Add polished voice controls and permission fallback in panel
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCaptureView.swift`
+- Modify: `macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCapturePanel.swift`
+
+- [ ] **Step 1:** bind text field to service draft text.
+- [ ] **Step 2:** add microphone start/stop control and visual recording status.
+- [ ] **Step 3:** add permission-denied guidance + open settings action.
+- [ ] **Step 4:** polish spacing/colors/typography to match app tokens.
+
+## Chunk 3: App Configuration + Verification
+
+### Task 3: Add required permission strings and verify
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Info.plist`
+
+- [ ] **Step 1:** add `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription`.
+- [ ] **Step 2:** run full tests.
+- [ ] **Step 3:** run Release build.
+

--- a/docs/superpowers/prs/2026-03-30-quick-capture-voice-mvp.md
+++ b/docs/superpowers/prs/2026-03-30-quick-capture-voice-mvp.md
@@ -1,0 +1,22 @@
+## Summary
+- add Quick Capture voice input MVP with click-to-start/stop recording
+- support bilingual transcription (`en-US` + `zh-CN`) and overwrite input behavior
+- add polished recording state UI and permission fallback guidance
+- add required microphone/speech permission usage descriptions
+
+## Linked Issue
+Closes #90
+
+## Changes
+- extended `QuickCaptureService` with voice capture state machine, permissions, and recognition pipeline
+- added bilingual recognition requests and transcript selection flow
+- bound Quick Capture input field to service draft text so speech results update live
+- redesigned Quick Capture panel controls for cleaner, more graceful UX
+- added permission-denied guidance with direct Settings shortcut
+- updated `Info.plist` for speech/microphone permission prompts
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`

--- a/macos/TodoFocusMac/Info.plist
+++ b/macos/TodoFocusMac/Info.plist
@@ -22,7 +22,11 @@
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>TodoFocus uses the microphone for optional Quick Capture voice input.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>TodoFocus uses speech recognition to transcribe Quick Capture voice notes.</string>
 </dict>
 </plist>

--- a/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
+++ b/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
@@ -1,5 +1,7 @@
 import AppKit
 import Observation
+import AVFoundation
+import Speech
 
 @Observable
 @MainActor
@@ -9,45 +11,55 @@ final class QuickCaptureService {
     var isHotkeyReady: Bool = false
     private var panel: QuickCapturePanel?
     private var hostingView: QuickCaptureHostingView?
-    
+
+    var draftText: String = ""
+    var isRecordingVoice: Bool = false
+    var voiceStatusMessage: String?
+    var voiceErrorMessage: String?
+    var needsVoicePermission: Bool = false
+
     var deepFocusService: DeepFocusService?
     var onCapture: ((String) -> Void)?
-    
+
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
-    
+    @ObservationIgnored private let audioEngine = AVAudioEngine()
+    @ObservationIgnored private var recognitionRequests: [String: SFSpeechAudioBufferRecognitionRequest] = [:]
+    @ObservationIgnored private var recognitionTasks: [String: SFSpeechRecognitionTask] = [:]
+    @ObservationIgnored private var transcriptsByLocale: [String: String] = [:]
+
     func setup() {
         checkAndRequestAccessibility()
         setupGlobalHotkey()
     }
-    
+
     private func checkAndRequestAccessibility() {
         let trusted = AXIsProcessTrusted()
         if !trusted {
             needsAccessibilityPermission = true
         }
     }
-    
+
     func requestAccessibilityPermission() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
             NSWorkspace.shared.open(url)
         }
     }
-    
+
     private func setupGlobalHotkey() {
         let eventMask: CGEventMask = (1 << CGEventType.keyDown.rawValue)
-        
+
         let callback: CGEventTapCallBack = { proxy, type, event, refcon in
             guard let refcon = refcon else { return Unmanaged.passUnretained(event) }
             let service = Unmanaged<QuickCaptureService>.fromOpaque(refcon).takeUnretainedValue()
-            
+
             if type == .keyDown {
                 let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
                 let flags = event.flags
-                
+
                 let hasCmd = flags.contains(.maskCommand)
                 let hasShift = flags.contains(.maskShift)
-                
+
                 if hasCmd && hasShift && keyCode == 17 {
                     Task { @MainActor in
                         service.showCapturePanel()
@@ -55,27 +67,32 @@ final class QuickCaptureService {
                     return nil
                 }
             }
-            
+
             return Unmanaged.passUnretained(event)
         }
-        
+
         let selfPtr = Unmanaged.passUnretained(self).toOpaque()
         eventTap = CGEvent.tapCreate(tap: .cgSessionEventTap, place: .headInsertEventTap, options: .defaultTap, eventsOfInterest: eventMask, callback: callback, userInfo: selfPtr)
-        
+
         guard let eventTap = eventTap else {
             return
         }
-        
+
         runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
         CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
         CGEvent.tapEnable(tap: eventTap, enable: true)
     }
-    
+
     func showCapturePanel() {
         if panel == nil {
             panel = QuickCapturePanel()
         }
-        
+
+        draftText = ""
+        voiceErrorMessage = nil
+        voiceStatusMessage = nil
+        needsVoicePermission = false
+
         let targetInfo: String
         if let dfService = deepFocusService, dfService.isActive {
             let count = dfService.blockedApps.count
@@ -83,8 +100,9 @@ final class QuickCaptureService {
         } else {
             targetInfo = "No Deep Focus - will add to Inbox"
         }
-        
+
         hostingView = QuickCaptureHostingView(
+            service: self,
             onSubmit: { [weak self] text in
                 self?.handleCapture(text)
             },
@@ -93,37 +111,222 @@ final class QuickCaptureService {
             },
             targetInfo: targetInfo
         )
-        
+
         panel?.contentView = hostingView
         panel?.showAtCenter()
         isVisible = true
     }
-    
+
+    func toggleVoiceCapture() async {
+        if isRecordingVoice {
+            stopVoiceCapture()
+            return
+        }
+        await startVoiceCapture()
+    }
+
+    func openVoicePermissionSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition") {
+            NSWorkspace.shared.open(url)
+            return
+        }
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func startVoiceCapture() async {
+        if isRecordingVoice {
+            return
+        }
+
+        voiceErrorMessage = nil
+        voiceStatusMessage = nil
+        transcriptsByLocale = [:]
+
+        let granted = await ensureVoicePermissions()
+        guard granted else {
+            needsVoicePermission = true
+            voiceErrorMessage = "Microphone and Speech Recognition permissions are required. You can still type manually."
+            return
+        }
+
+        do {
+            try beginRecognitionPipeline()
+            isRecordingVoice = true
+            needsVoicePermission = false
+            voiceStatusMessage = "Listening… click again to stop"
+        } catch {
+            isRecordingVoice = false
+            voiceStatusMessage = nil
+            voiceErrorMessage = "Unable to start voice capture. Please try again."
+            teardownRecognitionPipeline(cancelTasks: true)
+        }
+    }
+
+    private func stopVoiceCapture() {
+        if !isRecordingVoice && recognitionRequests.isEmpty {
+            return
+        }
+
+        isRecordingVoice = false
+        voiceStatusMessage = nil
+
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+
+        recognitionRequests.values.forEach { $0.endAudio() }
+
+        let best = bestTranscript()
+        if !best.isEmpty {
+            draftText = best
+        }
+
+        teardownRecognitionPipeline(cancelTasks: true)
+    }
+
+    private func beginRecognitionPipeline() throws {
+        teardownRecognitionPipeline(cancelTasks: true)
+
+        let localeIDs = ["en-US", "zh-CN"]
+
+        for localeID in localeIDs {
+            guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: localeID)),
+                  recognizer.isAvailable else {
+                continue
+            }
+
+            let request = SFSpeechAudioBufferRecognitionRequest()
+            request.shouldReportPartialResults = true
+            recognitionRequests[localeID] = request
+
+            recognitionTasks[localeID] = recognizer.recognitionTask(with: request) { [weak self] result, error in
+                Task { @MainActor in
+                    self?.handleRecognitionCallback(localeID: localeID, result: result, error: error)
+                }
+            }
+        }
+
+        if recognitionRequests.isEmpty {
+            throw NSError(domain: "QuickCaptureService", code: 1)
+        }
+
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        let activeRequests = Array(recognitionRequests.values)
+
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            for request in activeRequests {
+                request.append(buffer)
+            }
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+    }
+
+    private func handleRecognitionCallback(localeID: String, result: SFSpeechRecognitionResult?, error: Error?) {
+        if let result {
+            transcriptsByLocale[localeID] = result.bestTranscription.formattedString
+            let best = bestTranscript()
+            if !best.isEmpty {
+                draftText = best
+            }
+        }
+
+        if let _ = error, isRecordingVoice {
+            let best = bestTranscript()
+            if !best.isEmpty {
+                draftText = best
+            }
+        }
+    }
+
+    private func bestTranscript() -> String {
+        transcriptsByLocale.values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .max(by: { $0.count < $1.count }) ?? ""
+    }
+
+    private func teardownRecognitionPipeline(cancelTasks: Bool) {
+        if cancelTasks {
+            recognitionTasks.values.forEach { $0.cancel() }
+        }
+        recognitionTasks = [:]
+        recognitionRequests = [:]
+        transcriptsByLocale = [:]
+    }
+
+    private func ensureVoicePermissions() async -> Bool {
+        let speechAuthorized = await ensureSpeechAuthorization()
+        let microphoneAuthorized = await ensureMicrophoneAuthorization()
+        return speechAuthorized && microphoneAuthorized
+    }
+
+    private func ensureSpeechAuthorization() async -> Bool {
+        let status = SFSpeechRecognizer.authorizationStatus()
+        switch status {
+        case .authorized:
+            return true
+        case .notDetermined:
+            return await withCheckedContinuation { continuation in
+                SFSpeechRecognizer.requestAuthorization { authStatus in
+                    continuation.resume(returning: authStatus == .authorized)
+                }
+            }
+        case .restricted, .denied:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    private func ensureMicrophoneAuthorization() async -> Bool {
+        let status = AVCaptureDevice.authorizationStatus(for: .audio)
+        switch status {
+        case .authorized:
+            return true
+        case .notDetermined:
+            return await withCheckedContinuation { continuation in
+                AVCaptureDevice.requestAccess(for: .audio) { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+        case .denied, .restricted:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
     private func handleCapture(_ text: String) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             hidePanel()
             return
         }
-        
+
         let timestamp = formatTimestamp(Date())
         let captureText = "\n[\(timestamp)] \(trimmed)"
         onCapture?(captureText)
         hidePanel()
     }
-    
+
     private func formatTimestamp(_ date: Date) -> String {
         let formatter = DateFormatter()
         formatter.timeStyle = .short
         return formatter.string(from: date)
     }
-    
+
     private func hidePanel() {
+        stopVoiceCapture()
         panel?.orderOut(nil)
         isVisible = false
     }
-    
+
     func cleanup() {
+        stopVoiceCapture()
         if let eventTap = eventTap {
             CGEvent.tapEnable(tap: eventTap, enable: false)
         }

--- a/macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCapturePanel.swift
+++ b/macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCapturePanel.swift
@@ -3,7 +3,7 @@ import AppKit
 class QuickCapturePanel: NSPanel {
     init() {
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 140),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 220),
             styleMask: [.titled, .closable, .nonactivatingPanel, .hudWindow, .utilityWindow],
             backing: .buffered,
             defer: false
@@ -15,7 +15,7 @@ class QuickCapturePanel: NSPanel {
         self.titleVisibility = .hidden
         self.titlebarAppearsTransparent = true
         self.isMovableByWindowBackground = true
-        self.backgroundColor = NSColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 0.95)
+        self.backgroundColor = NSColor(red: 0.07, green: 0.07, blue: 0.08, alpha: 0.94)
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         self.isOpaque = false
         self.hasShadow = true
@@ -24,8 +24,8 @@ class QuickCapturePanel: NSPanel {
     func showAtCenter() {
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
-            let x = screenFrame.midX - 200
-            let y = screenFrame.midY - 70
+            let x = screenFrame.midX - 240
+            let y = screenFrame.midY - 110
             self.setFrameOrigin(NSPoint(x: x, y: y))
         }
         self.makeKeyAndOrderFront(nil)

--- a/macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCaptureView.swift
+++ b/macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCaptureView.swift
@@ -1,74 +1,128 @@
 import SwiftUI
 
 struct QuickCaptureView: View {
-    @Binding var text: String
+    @Bindable var service: QuickCaptureService
     let onSubmit: () -> Void
     let onCancel: () -> Void
     let targetInfo: String
+    @Environment(\.themeTokens) private var tokens
     @State private var isSubmitting = false
     @State private var showSuccess = false
-    
+
     var body: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 14) {
             HStack {
-                Image(systemName: "lightbulb.fill")
-                    .foregroundColor(Color(hex: "C46849"))
-                    .font(.system(size: 16))
+                Image(systemName: "sparkles")
+                    .foregroundStyle(tokens.accentTerracotta)
+                    .font(.system(size: 16, weight: .semibold))
                 Text("Quick Capture")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundColor(.white)
+                    .font(.headline)
+                    .foregroundStyle(tokens.textPrimary)
                 Spacer()
                 Text(targetInfo)
                     .font(.caption)
-                    .foregroundColor(.white.opacity(0.6))
+                    .foregroundStyle(tokens.textSecondary)
             }
-            
+
             HStack {
-                TextField("Capture a thought...", text: $text)
+                TextField("Capture a thought...", text: $service.draftText)
                     .textFieldStyle(.plain)
                     .padding(10)
-                    .background(Color.white.opacity(0.1))
+                    .background(tokens.inputSurface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(tokens.inputBorder, lineWidth: 1)
+                    )
                     .cornerRadius(8)
-                    .foregroundColor(.white)
+                    .foregroundStyle(tokens.textPrimary)
                     .scaleEffect(isSubmitting ? 0.98 : 1.0)
                     .animation(.easeInOut(duration: 0.1), value: isSubmitting)
                     .onSubmit {
                         handleSubmit()
                     }
-                
+
+                Button {
+                    Task {
+                        await service.toggleVoiceCapture()
+                    }
+                } label: {
+                    Image(systemName: service.isRecordingVoice ? "stop.circle.fill" : "mic.circle.fill")
+                        .font(.system(size: 24))
+                        .foregroundStyle(service.isRecordingVoice ? tokens.danger : tokens.accentTerracotta)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(service.isRecordingVoice ? "Stop recording" : "Start recording")
+
                 if showSuccess {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
+                        .foregroundStyle(tokens.success)
                         .font(.system(size: 20))
                         .transition(.scale.combined(with: .opacity))
                 }
             }
-            
+
+            if let status = service.voiceStatusMessage {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(service.isRecordingVoice ? tokens.danger : tokens.textSecondary)
+                        .frame(width: 6, height: 6)
+                    Text(status)
+                        .font(.caption)
+                        .foregroundStyle(tokens.textSecondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if let error = service.voiceErrorMessage {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(tokens.warning)
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(tokens.warning)
+                    if service.needsVoicePermission {
+                        Button("Open Settings") {
+                            service.openVoicePermissionSettings()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
             HStack {
                 Spacer()
                 Button("Cancel") {
                     onCancel()
                 }
                 .buttonStyle(.plain)
-                .foregroundColor(.white.opacity(0.7))
+                .foregroundStyle(tokens.textSecondary)
                 .keyboardShortcut(.escape)
-                
+
                 Button("Add") {
                     handleSubmit()
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(Color(hex: "C46849"))
+                .tint(tokens.accentTerracotta)
                 .keyboardShortcut(.return)
             }
         }
         .padding(16)
-        .frame(width: 400, height: 140)
-        .background(Color.clear)
+        .frame(width: 480, height: 220)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(tokens.bgElevated)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(tokens.sectionBorder, lineWidth: 1)
+        )
         .animation(.easeInOut(duration: 0.2), value: showSuccess)
     }
-    
+
     private func handleSubmit() {
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !service.draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             onCancel()
             return
         }
@@ -86,27 +140,21 @@ struct QuickCaptureView: View {
 class QuickCaptureHostingView: NSHostingView<QuickCaptureView> {
     private let onSubmit: (String) -> Void
     private let onCancel: () -> Void
-    
+
     required init(rootView: QuickCaptureView) {
         self.onSubmit = { _ in }
         self.onCancel = { }
         super.init(rootView: rootView)
     }
-    
-    init(onSubmit: @escaping (String) -> Void, onCancel: @escaping () -> Void, targetInfo: String) {
+
+    init(service: QuickCaptureService, onSubmit: @escaping (String) -> Void, onCancel: @escaping () -> Void, targetInfo: String) {
         self.onSubmit = onSubmit
         self.onCancel = onCancel
-        
-        var textValue: String = ""
-        let textBinding = Binding<String>(
-            get: { textValue },
-            set: { textValue = $0 }
-        )
-        
+
         let view = QuickCaptureView(
-            text: textBinding,
+            service: service,
             onSubmit: {
-                onSubmit(textValue)
+                onSubmit(service.draftText)
             },
             onCancel: onCancel,
             targetInfo: targetInfo


### PR DESCRIPTION
## Summary
- add Quick Capture voice input MVP with click-to-start/stop recording
- support bilingual transcription (`en-US` + `zh-CN`) and overwrite input behavior
- add polished recording state UI and permission fallback guidance
- add required microphone/speech permission usage descriptions

## Linked Issue
Closes #90

## Changes
- extended `QuickCaptureService` with voice capture state machine, permissions, and recognition pipeline
- added bilingual recognition requests and transcript selection flow
- bound Quick Capture input field to service draft text so speech results update live
- redesigned Quick Capture panel controls for cleaner, more graceful UX
- added permission-denied guidance with direct Settings shortcut
- updated `Info.plist` for speech/microphone permission prompts

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`
