### PR TITLE
Fix Quick Capture mic-permission crash after voice MVP merge

### DIFF
--- a/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
+++ b/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
@@ -264,7 +264,7 @@ final class QuickCaptureService {
         return speechAuthorized && microphoneAuthorized
     }
 
-    private func ensureSpeechAuthorization() async -> Bool {
+    nonisolated private func ensureSpeechAuthorization() async -> Bool {
         let status = SFSpeechRecognizer.authorizationStatus()
         switch status {
         case .authorized:
@@ -282,7 +282,7 @@ final class QuickCaptureService {
         }
     }
 
-    private func ensureMicrophoneAuthorization() async -> Bool {
+    nonisolated private func ensureMicrophoneAuthorization() async -> Bool {
         let status = AVCaptureDevice.authorizationStatus(for: .audio)
         switch status {
         case .authorized:


### PR DESCRIPTION
## 1. Crash Root Cause (Confirmed)

- The crash stack shows `Thread 6` failing at `_dispatch_assert_queue_fail`, traced to the callback path in `QuickCaptureService.ensureMicrophoneAuthorization()`.
- This code runs inside an `@MainActor` type, while `AVCaptureDevice.requestAccess` invokes its callback on a background queue.
- That mismatch triggers a Swift concurrency executor isolation assertion (`SIGTRAP`).
- Fix location:
  - `macos/TodoFocusMac/Sources/App/QuickCaptureService.swift:267`

## 2. Minimal Fix

- Marked both permission helper methods as `nonisolated`:
  - `ensureSpeechAuthorization()`
  - `ensureMicrophoneAuthorization()`
- This prevents the permission callbacks from inheriting `MainActor` isolation and eliminates the assertion crash.

## 3. Note on the Horizontal Scrolling Issue

- The time-filter chips horizontal scrolling behavior was also fixed.
- The chips now keep intrinsic width and scroll horizontally instead of being squeezed in narrow layouts.
- That change was shipped in PR #93 on branch `fix/92`.

## 4. Pushed Commits

- Time-filter horizontal scrolling fix (PR #93 / `fix/92`): `04ba926`
- Microphone-permission crash fix (this PR #94 / `feat/90`): `bea2ccb`

## 5. Verification

- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`

## Context

- Follow-up fix after merged PR #91
- Related UI behavior update already merged in PR #93
