### PR TITLE
Fix time-filter chips horizontal scrolling on narrow widths

### DIFF
--- a/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
@@ -400,9 +400,11 @@ struct TaskListView: View {
                     .buttonStyle(.plain)
                 }
             }
+            .fixedSize(horizontal: true, vertical: false)
         }
         .padding(.horizontal, 4)
         .padding(.vertical, 3)
+        .frame(maxWidth: 430)
         .background(tokens.bgElevated.opacity(0.78), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 14, style: .continuous)


### PR DESCRIPTION
## Summary
- add the missing horizontal-scroll enforcement for time-filter chips
- keep chip intrinsic width so labels do not get squeezed in narrow layouts

## Change
- in `TaskListView.filterPicker`, set chip row to fixed intrinsic width and keep scroll container behavior

## Why this PR
- follow-up to include commit `04ba926` into `main` (it was not included in merged history)

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
