### PR TITLE
Fix voice tap callback crash and enlarge detail resize hit area

### DIFF
--- a/docs/superpowers/issues/2026-03-30-voice-tap-crash-and-detail-resize-hit-area.md
+++ b/docs/superpowers/issues/2026-03-30-voice-tap-crash-and-detail-resize-hit-area.md
@@ -1,0 +1,26 @@
+# Fix Quick Capture audio tap crash + enlarge detail resize hit area
+
+## Problem 1: Voice capture still crashes
+- Crash now points to `closure #2 in QuickCaptureService.beginRecognitionPipeline()` on queue `RealtimeMessenger.mServiceQueue`.
+- This indicates executor/isolation mismatch inside the audio tap callback path.
+
+## Root Cause (confirmed)
+- `QuickCaptureService` is `@MainActor`.
+- `AVAudioEngine` tap callback runs on a realtime/background queue.
+- The callback closure created in actor-isolated context trips concurrency isolation assertion at runtime.
+
+## Fix Plan
+- Move tap installation callback creation into a `nonisolated` helper so callback execution is not actor-isolated.
+- Keep behavior unchanged (still appending audio buffers to both recognition requests).
+
+## Problem 2: Detail panel resize drag area is too narrow
+- Divider is currently hard to hit reliably.
+
+## Fix Plan
+- Increase drag hit-target width while keeping a slim visual divider line.
+- Preserve current width clamp/persistence behavior.
+
+## Acceptance Criteria
+- No crash when granting permission and starting voice capture.
+- Detail panel divider is easier to grab and resize.
+- Full tests and release build pass.

--- a/docs/superpowers/plans/2026-03-30-voice-tap-crash-and-resize-hit-area-fix.md
+++ b/docs/superpowers/plans/2026-03-30-voice-tap-crash-and-resize-hit-area-fix.md
@@ -1,0 +1,40 @@
+# Voice Tap Crash + Detail Resize Hit Area Fix Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Quick Capture voice tap callback crash and make detail-panel resize divider easier to drag.
+
+**Architecture:** Keep behavior the same but move realtime audio-tap closure creation out of actor-isolated context, and increase divider hit target while preserving current width persistence/clamping path.
+
+**Tech Stack:** SwiftUI, AVFoundation, Speech, Swift Concurrency.
+
+---
+
+## Chunk 1: Crash Fix
+
+### Task 1: Nonisolated audio tap callback path
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Sources/App/QuickCaptureService.swift`
+
+- [ ] Add a `nonisolated` helper that installs tap and appends buffers to recognition requests.
+- [ ] Update `beginRecognitionPipeline()` to use helper and keep logic minimal.
+- [ ] Verify no behavior drift in start/stop flow.
+
+## Chunk 2: Divider UX
+
+### Task 2: Enlarge detail resize hit area
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Sources/RootView.swift`
+
+- [ ] Expand drag hit region width.
+- [ ] Keep visual divider slim with center line overlay.
+- [ ] Keep existing drag math and width persistence.
+
+## Chunk 3: Verification
+
+### Task 3: Run full verification
+
+- [ ] `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+- [ ] `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`

--- a/docs/superpowers/prs/2026-03-30-voice-tap-crash-and-detail-resize-hit-area.md
+++ b/docs/superpowers/prs/2026-03-30-voice-tap-crash-and-detail-resize-hit-area.md
@@ -1,0 +1,21 @@
+## Summary
+- fix Quick Capture crash in realtime audio tap callback path
+- enlarge right detail-panel resize divider hit area for easier dragging
+
+## Linked Issue
+Closes #96
+
+## Root Cause
+- `QuickCaptureService` is `@MainActor`, but AVAudio tap callback executes on a realtime queue.
+- Callback creation in actor-isolated context caused runtime executor isolation assertion.
+
+## Changes
+- moved audio tap installation callback path into a `nonisolated` static helper (`installAudioTap`) in `QuickCaptureService`
+- kept recognition flow behavior unchanged (still appends buffer to each active recognition request)
+- expanded detail resize hit target from narrow line to larger transparent drag zone with slim visual center line
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`

--- a/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
+++ b/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
@@ -215,12 +215,7 @@ final class QuickCaptureService {
         let format = inputNode.outputFormat(forBus: 0)
         let activeRequests = Array(recognitionRequests.values)
 
-        inputNode.removeTap(onBus: 0)
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
-            for request in activeRequests {
-                request.append(buffer)
-            }
-        }
+        Self.installAudioTap(inputNode: inputNode, format: format, requests: activeRequests)
 
         audioEngine.prepare()
         try audioEngine.start()
@@ -262,6 +257,19 @@ final class QuickCaptureService {
         let speechAuthorized = await ensureSpeechAuthorization()
         let microphoneAuthorized = await ensureMicrophoneAuthorization()
         return speechAuthorized && microphoneAuthorized
+    }
+
+    nonisolated private static func installAudioTap(
+        inputNode: AVAudioInputNode,
+        format: AVAudioFormat,
+        requests: [SFSpeechAudioBufferRecognitionRequest]
+    ) {
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            for request in requests {
+                request.append(buffer)
+            }
+        }
     }
 
     nonisolated private func ensureSpeechAuthorization() async -> Bool {

--- a/macos/TodoFocusMac/Sources/RootView.swift
+++ b/macos/TodoFocusMac/Sources/RootView.swift
@@ -44,8 +44,13 @@ struct RootView: View {
 
                 if store.selectedTodo != nil {
                     Rectangle()
-                        .fill(themeTokens.sectionBorder.opacity(0.85))
-                        .frame(width: 5)
+                        .fill(.clear)
+                        .frame(width: 14)
+                        .overlay {
+                            Rectangle()
+                                .fill(themeTokens.sectionBorder.opacity(0.9))
+                                .frame(width: 3)
+                        }
                         .contentShape(Rectangle())
                         .gesture(
                             DragGesture(minimumDistance: 0)


### PR DESCRIPTION
## Summary
- fix Quick Capture crash in realtime audio tap callback path
- enlarge right detail-panel resize divider hit area for easier dragging

## Linked Issue
Closes #96

## Root Cause
- `QuickCaptureService` is `@MainActor`, but AVAudio tap callback executes on a realtime queue.
- Callback creation in actor-isolated context caused runtime executor isolation assertion.

## Changes
- moved audio tap installation callback path into a `nonisolated` static helper (`installAudioTap`) in `QuickCaptureService`
- kept recognition flow behavior unchanged (still appends buffer to each active recognition request)
- expanded detail resize hit target from narrow line to larger transparent drag zone with slim visual center line

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`
