### PR TITLE
fix: improve Quick Capture voice recognition quality (EN primary + ZH fallback)

### DIFF
--- a/docs/superpowers/issues/2026-03-30-voice-recognition-quality-pass.md
+++ b/docs/superpowers/issues/2026-03-30-voice-recognition-quality-pass.md
@@ -1,0 +1,18 @@
+# Improve Quick Capture voice recognition quality (EN primary, ZH fallback)
+
+## Goals
+- Use English as primary recognition locale with Chinese fallback.
+- Add explicit UI reminder about language strategy.
+- Change result fusion strategy to: final transcript has priority, partial transcript is preview only.
+- Add short silence auto-finalize endpoint behavior.
+- Keep local-only implementation (no cloud API dependency).
+
+## Scope
+- `QuickCaptureService` recognition state and fusion policy.
+- `QuickCaptureView` UI reminder and preview display.
+
+## Acceptance Criteria
+- Recognition chooses `en-US` final text first, then `zh-CN` final as fallback.
+- Partial text does not overwrite committed draft; it is preview-only.
+- Recording auto-stops after short silence inactivity.
+- Full tests/build pass.

--- a/docs/superpowers/plans/2026-03-30-voice-recognition-quality-pass.md
+++ b/docs/superpowers/plans/2026-03-30-voice-recognition-quality-pass.md
@@ -1,0 +1,27 @@
+# Voice Recognition Quality Pass Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve Quick Capture voice quality using EN-primary/ZH-fallback strategy, final-first fusion, and silence auto-finalize.
+
+**Architecture:** Keep dual recognizers but separate partial vs final transcript state per locale. Commit only final transcript to draft; show partial as preview in UI. Add inactivity-based auto-finalize timer reset on each recognition callback.
+
+**Tech Stack:** SwiftUI, AVFoundation, Speech, Swift Concurrency.
+
+---
+
+## Task 1: Recognition policy updates
+- Modify `QuickCaptureService.swift`
+- [ ] Add locale-prioritized transcript selection helpers (EN first, ZH fallback)
+- [ ] Separate partial and final transcript stores
+- [ ] Apply final-first policy: only final updates committed text
+- [ ] Add silence timer that auto-stops recording after short inactivity
+
+## Task 2: UI reminder and preview
+- Modify `QuickCaptureView.swift`
+- [ ] Add language reminder text (EN primary, ZH fallback)
+- [ ] Show partial transcript preview line while recording
+
+## Task 3: Verify
+- [ ] `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+- [ ] `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`

--- a/docs/superpowers/prs/2026-03-30-voice-recognition-quality-pass.md
+++ b/docs/superpowers/prs/2026-03-30-voice-recognition-quality-pass.md
@@ -1,0 +1,35 @@
+## Summary
+- improve Quick Capture voice quality with English-primary and Chinese-fallback recognition flow
+- prioritize final recognition results for saved text; keep partial results as preview only
+- add short-silence auto-finalize so capture ends automatically after speech pause
+- add inline UI reminder about language behavior and show partial preview while recording
+
+## Linked Issue
+Closes #98
+
+## Root Cause
+- voice capture previously mixed partial and final transcripts into the same committed field, which caused unstable output and poor perceived accuracy
+- there was no endpointing behavior, so users had to manually stop every capture and often got incomplete final text
+- language strategy was not explicit in product UX, so expected bilingual behavior was unclear
+
+## Changes
+- recognition locales now run in fixed priority order: `en-US` primary, `zh-CN` fallback
+- split transcript states into:
+  - `finalTranscriptsByLocale` for committed text
+  - `partialTranscriptsByLocale` + `voicePreviewText` for live preview only
+- commit path now writes only `bestFinalTranscript()` to `draftText`
+- added short-silence endpointing (`1.2s`) with auto-stop and status feedback
+- updated Quick Capture UI:
+  - language reminder text (English primary, Chinese fallback)
+  - preview row for partial transcripts while recording
+  - slightly larger panel frame for improved readability
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`
+
+## Notes
+- no cloud speech API added in this PR; recognition remains on-device via Apple speech stack
+- follow-up reminder tracked: keep English as default primary language, Chinese as fallback in future voice quality iterations

--- a/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
+++ b/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
@@ -6,6 +6,10 @@ import Speech
 @Observable
 @MainActor
 final class QuickCaptureService {
+    private static let primaryLocaleID = "en-US"
+    private static let fallbackLocaleID = "zh-CN"
+    private static let silenceAutoFinalizeSeconds: TimeInterval = 1.2
+
     var isVisible: Bool = false
     var needsAccessibilityPermission: Bool = false
     var isHotkeyReady: Bool = false
@@ -17,6 +21,7 @@ final class QuickCaptureService {
     var voiceStatusMessage: String?
     var voiceErrorMessage: String?
     var needsVoicePermission: Bool = false
+    var voicePreviewText: String?
 
     var deepFocusService: DeepFocusService?
     var onCapture: ((String) -> Void)?
@@ -26,7 +31,9 @@ final class QuickCaptureService {
     @ObservationIgnored private let audioEngine = AVAudioEngine()
     @ObservationIgnored private var recognitionRequests: [String: SFSpeechAudioBufferRecognitionRequest] = [:]
     @ObservationIgnored private var recognitionTasks: [String: SFSpeechRecognitionTask] = [:]
-    @ObservationIgnored private var transcriptsByLocale: [String: String] = [:]
+    @ObservationIgnored private var finalTranscriptsByLocale: [String: String] = [:]
+    @ObservationIgnored private var partialTranscriptsByLocale: [String: String] = [:]
+    @ObservationIgnored private var silenceAutoFinalizeWorkItem: DispatchWorkItem?
 
     func setup() {
         checkAndRequestAccessibility()
@@ -92,6 +99,7 @@ final class QuickCaptureService {
         voiceErrorMessage = nil
         voiceStatusMessage = nil
         needsVoicePermission = false
+        voicePreviewText = nil
 
         let targetInfo: String
         if let dfService = deepFocusService, dfService.isActive {
@@ -142,7 +150,10 @@ final class QuickCaptureService {
 
         voiceErrorMessage = nil
         voiceStatusMessage = nil
-        transcriptsByLocale = [:]
+        voicePreviewText = nil
+        finalTranscriptsByLocale = [:]
+        partialTranscriptsByLocale = [:]
+        cancelSilenceAutoFinalize()
 
         let granted = await ensureVoicePermissions()
         guard granted else {
@@ -155,7 +166,8 @@ final class QuickCaptureService {
             try beginRecognitionPipeline()
             isRecordingVoice = true
             needsVoicePermission = false
-            voiceStatusMessage = "Listening… click again to stop"
+            voiceStatusMessage = "Listening… English primary, Chinese fallback"
+            scheduleSilenceAutoFinalize()
         } catch {
             isRecordingVoice = false
             voiceStatusMessage = nil
@@ -171,13 +183,14 @@ final class QuickCaptureService {
 
         isRecordingVoice = false
         voiceStatusMessage = nil
+        cancelSilenceAutoFinalize()
 
         audioEngine.stop()
         audioEngine.inputNode.removeTap(onBus: 0)
 
         recognitionRequests.values.forEach { $0.endAudio() }
 
-        let best = bestTranscript()
+        let best = bestFinalTranscript()
         if !best.isEmpty {
             draftText = best
         }
@@ -188,7 +201,7 @@ final class QuickCaptureService {
     private func beginRecognitionPipeline() throws {
         teardownRecognitionPipeline(cancelTasks: true)
 
-        let localeIDs = ["en-US", "zh-CN"]
+        let localeIDs = [Self.primaryLocaleID, Self.fallbackLocaleID]
 
         for localeID in localeIDs {
             guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: localeID)),
@@ -223,25 +236,61 @@ final class QuickCaptureService {
 
     private func handleRecognitionCallback(localeID: String, result: SFSpeechRecognitionResult?, error: Error?) {
         if let result {
-            transcriptsByLocale[localeID] = result.bestTranscription.formattedString
-            let best = bestTranscript()
-            if !best.isEmpty {
-                draftText = best
+            let text = result.bestTranscription.formattedString.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                if result.isFinal {
+                    finalTranscriptsByLocale[localeID] = text
+                    partialTranscriptsByLocale[localeID] = nil
+                    voicePreviewText = nil
+                    let bestFinal = bestFinalTranscript()
+                    if !bestFinal.isEmpty {
+                        draftText = bestFinal
+                    }
+                } else {
+                    partialTranscriptsByLocale[localeID] = text
+                    voicePreviewText = bestPartialPreview()
+                }
+                scheduleSilenceAutoFinalize()
             }
         }
 
         if let _ = error, isRecordingVoice {
-            let best = bestTranscript()
-            if !best.isEmpty {
-                draftText = best
-            }
+            voiceStatusMessage = "Listening interrupted, tap mic to retry"
         }
     }
 
-    private func bestTranscript() -> String {
-        transcriptsByLocale.values
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .max(by: { $0.count < $1.count }) ?? ""
+    private func bestFinalTranscript() -> String {
+        for localeID in [Self.primaryLocaleID, Self.fallbackLocaleID] {
+            if let text = finalTranscriptsByLocale[localeID], !text.isEmpty {
+                return text
+            }
+        }
+        return finalTranscriptsByLocale.values.first(where: { !$0.isEmpty }) ?? ""
+    }
+
+    private func bestPartialPreview() -> String? {
+        for localeID in [Self.primaryLocaleID, Self.fallbackLocaleID] {
+            if let text = partialTranscriptsByLocale[localeID], !text.isEmpty {
+                return text
+            }
+        }
+        return partialTranscriptsByLocale.values.first(where: { !$0.isEmpty })
+    }
+
+    private func scheduleSilenceAutoFinalize() {
+        cancelSilenceAutoFinalize()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, self.isRecordingVoice else { return }
+            self.stopVoiceCapture()
+            self.voiceStatusMessage = "Auto-stopped after short silence"
+        }
+        silenceAutoFinalizeWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.silenceAutoFinalizeSeconds, execute: workItem)
+    }
+
+    private func cancelSilenceAutoFinalize() {
+        silenceAutoFinalizeWorkItem?.cancel()
+        silenceAutoFinalizeWorkItem = nil
     }
 
     private func teardownRecognitionPipeline(cancelTasks: Bool) {
@@ -250,7 +299,9 @@ final class QuickCaptureService {
         }
         recognitionTasks = [:]
         recognitionRequests = [:]
-        transcriptsByLocale = [:]
+        finalTranscriptsByLocale = [:]
+        partialTranscriptsByLocale = [:]
+        voicePreviewText = nil
     }
 
     private func ensureVoicePermissions() async -> Bool {

--- a/macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCaptureView.swift
+++ b/macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCaptureView.swift
@@ -24,6 +24,11 @@ struct QuickCaptureView: View {
                     .foregroundStyle(tokens.textSecondary)
             }
 
+            Text("Voice mode reminder: English is primary, Chinese is fallback.")
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(tokens.textTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
             HStack {
                 TextField("Capture a thought...", text: $service.draftText)
                     .textFieldStyle(.plain)
@@ -73,6 +78,18 @@ struct QuickCaptureView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
+            if service.isRecordingVoice, let preview = service.voicePreviewText, !preview.isEmpty {
+                HStack(spacing: 6) {
+                    Image(systemName: "waveform")
+                        .foregroundStyle(tokens.accentTerracotta)
+                    Text("Preview: \(preview)")
+                        .font(.caption)
+                        .foregroundStyle(tokens.textSecondary)
+                        .lineLimit(2)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
             if let error = service.voiceErrorMessage {
                 HStack(spacing: 8) {
                     Image(systemName: "exclamationmark.triangle.fill")
@@ -109,7 +126,7 @@ struct QuickCaptureView: View {
             }
         }
         .padding(16)
-        .frame(width: 480, height: 220)
+        .frame(width: 500, height: 250)
         .background(
             RoundedRectangle(cornerRadius: 12)
                 .fill(tokens.bgElevated)


### PR DESCRIPTION
## Summary
- improve Quick Capture voice quality with English-primary and Chinese-fallback recognition flow
- prioritize final recognition results for saved text; keep partial results as preview only
- add short-silence auto-finalize so capture ends automatically after speech pause
- add inline UI reminder about language behavior and show partial preview while recording

## Linked Issue
Closes #98

## Root Cause
- voice capture previously mixed partial and final transcripts into the same committed field, which caused unstable output and poor perceived accuracy
- there was no endpointing behavior, so users had to manually stop every capture and often got incomplete final text
- language strategy was not explicit in product UX, so expected bilingual behavior was unclear

## Changes
- recognition locales now run in fixed priority order: `en-US` primary, `zh-CN` fallback
- split transcript states into:
  - `finalTranscriptsByLocale` for committed text
  - `partialTranscriptsByLocale` + `voicePreviewText` for live preview only
- commit path now writes only `bestFinalTranscript()` to `draftText`
- added short-silence endpointing (`1.2s`) with auto-stop and status feedback
- updated Quick Capture UI:
  - language reminder text (English primary, Chinese fallback)
  - preview row for partial transcripts while recording
  - slightly larger panel frame for improved readability
- polished Task List filter/header visuals:
  - removed unnecessary trailing blank area in filter capsule
  - kept horizontal scrolling behavior without squeezing in narrow widths
  - refined numeric chips with lighter visual weight and monospaced digits
- polished Launchpad add-resource form visuals:
  - improved spacing rhythm and rounded corners
  - switched inputs to tokenized input surfaces/borders
  - unified type chips and action buttons with clearer hierarchy and softer contrast

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`

## Notes
- no cloud speech API added in this PR; recognition remains on-device via Apple speech stack
- follow-up reminder tracked: keep English as default primary language, Chinese as fallback in future voice quality iterations
