### PR TITLE
fix(ui): polish task-detail header seam near Deep Focus

### DIFF
--- a/docs/superpowers/issues/2026-03-31-task-detail-header-seam-polish.md
+++ b/docs/superpowers/issues/2026-03-31-task-detail-header-seam-polish.md
@@ -1,0 +1,14 @@
+## Summary
+Polish the visual seam between the task title input surface and the Deep Focus action group in task detail header.
+
+## Problem
+- The boundary between the left title field container and right action controls appears abrupt.
+- The transition feels visually harsh in dark mode.
+
+## Expected
+- Softer transition between left and right header controls.
+- Deep Focus action group should feel integrated with title section instead of detached.
+
+## Scope
+- Task detail header visual polish only.
+- No behavior change to title editing or focus actions.

--- a/docs/superpowers/prs/2026-03-31-task-detail-header-seam-polish.md
+++ b/docs/superpowers/prs/2026-03-31-task-detail-header-seam-polish.md
@@ -1,0 +1,17 @@
+## Summary
+- soften the visual seam between title input and Deep Focus controls in task detail header
+- make the trailing action cluster feel integrated instead of detached
+
+## Linked Issue
+Closes #107
+
+## Changes
+- reduced header control spacing to tighten the transition
+- added a subtle trailing blend gradient on the title input container edge
+- wrapped the Deep Focus/Close control group in a low-contrast rounded surface with border
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`

--- a/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
@@ -142,7 +142,7 @@ struct TaskDetailView: View {
         let titleGlowOpacity: Double = (isTitleFocused && !hasValidationError) ? 0.10 : 0
 
         return VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 8) {
+            HStack(spacing: 6) {
                 VStack(alignment: .leading, spacing: 6) {
                     TextField("Task title", text: $titleText)
                         .textFieldStyle(.plain)
@@ -183,6 +183,15 @@ struct TaskDetailView: View {
                 .animation(MotionTokens.focusEase, value: isTitleFocused)
                 .animation(MotionTokens.validationEase, value: hasValidationError)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .overlay(alignment: .trailing) {
+                    LinearGradient(
+                        colors: [Color.clear, tokens.sectionBackground.opacity(0.78)],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .frame(width: 18)
+                    .allowsHitTesting(false)
+                }
 
                 HStack(spacing: 10) {
                     Button {
@@ -215,6 +224,16 @@ struct TaskDetailView: View {
                     }
                     .buttonStyle(.plain)
                     .foregroundStyle(tokens.mutedText)
+                }
+                .padding(.horizontal, 6)
+                .padding(.vertical, 4)
+                .background(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(Color.white.opacity(0.035))
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(tokens.sectionBorder.opacity(0.78), lineWidth: 1)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- soften the visual seam between title input and Deep Focus controls in task detail header
- make the trailing action cluster feel integrated instead of detached

## Linked Issue
Closes #107

## Changes
- reduced header control spacing to tighten the transition
- added a subtle trailing blend gradient on the title input container edge
- wrapped the Deep Focus/Close control group in a low-contrast rounded surface with border

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`
