### PR TITLE
fix: polish Daily Review + detail header and switch voice capture to English-only

### DIFF
--- a/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
+++ b/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
@@ -7,8 +7,7 @@ import Speech
 @MainActor
 final class QuickCaptureService {
     private static let primaryLocaleID = "en-US"
-    private static let fallbackLocaleID = "zh-CN"
-    private static let silenceAutoFinalizeSeconds: TimeInterval = 1.2
+    private static let silenceAutoFinalizeSeconds: TimeInterval = 1.6
 
     var isVisible: Bool = false
     var needsAccessibilityPermission: Bool = false
@@ -170,7 +169,7 @@ final class QuickCaptureService {
             try beginRecognitionPipeline()
             isRecordingVoice = true
             needsVoicePermission = false
-            voiceStatusMessage = "Listening… English primary, Chinese fallback"
+            voiceStatusMessage = "Listening… English only"
         } catch {
             isRecordingVoice = false
             voiceStatusMessage = nil
@@ -196,6 +195,8 @@ final class QuickCaptureService {
         let best = bestFinalTranscript()
         if !best.isEmpty {
             draftText = best
+        } else if let preview = bestPartialPreview(), !preview.isEmpty {
+            draftText = preview
         }
 
         teardownRecognitionPipeline(cancelTasks: true)
@@ -204,7 +205,7 @@ final class QuickCaptureService {
     private func beginRecognitionPipeline() throws {
         teardownRecognitionPipeline(cancelTasks: true)
 
-        let localeIDs = [Self.primaryLocaleID, Self.fallbackLocaleID]
+        let localeIDs = [Self.primaryLocaleID]
 
         for localeID in localeIDs {
             guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: localeID)),
@@ -270,7 +271,7 @@ final class QuickCaptureService {
     }
 
     private func bestFinalTranscript() -> String {
-        for localeID in [Self.primaryLocaleID, Self.fallbackLocaleID] {
+        for localeID in [Self.primaryLocaleID] {
             if let text = finalTranscriptsByLocale[localeID], !text.isEmpty {
                 return text
             }
@@ -279,7 +280,7 @@ final class QuickCaptureService {
     }
 
     private func bestPartialPreview() -> String? {
-        for localeID in [Self.primaryLocaleID, Self.fallbackLocaleID] {
+        for localeID in [Self.primaryLocaleID] {
             if let text = partialTranscriptsByLocale[localeID], !text.isEmpty {
                 return text
             }

--- a/macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCaptureView.swift
+++ b/macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCaptureView.swift
@@ -24,7 +24,7 @@ struct QuickCaptureView: View {
                     .foregroundStyle(tokens.textSecondary)
             }
 
-            Text("Voice mode reminder: English is primary, Chinese is fallback.")
+            Text("Voice mode reminder: English only.")
                 .font(.caption2.weight(.medium))
                 .foregroundStyle(tokens.textTertiary)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -15,7 +15,7 @@ struct DailyReviewView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 14) {
             header
             summaryPanel
 
@@ -23,79 +23,122 @@ struct DailyReviewView: View {
                 emptyState
             } else {
                 ScrollView {
-                    LazyVStack(spacing: 8) {
+                    LazyVStack(spacing: 10) {
                         ForEach(reviewTodos) { todo in
                             reviewRow(todo)
                         }
                     }
-                    .padding(.top, 2)
+                    .padding(.bottom, 10)
                 }
+                .scrollIndicators(.visible)
             }
         }
         .padding(16)
     }
 
     private var header: some View {
-        HStack(spacing: 10) {
-            Text("Daily Review")
-                .font(.system(size: 22, weight: .bold, design: .rounded))
-                .foregroundStyle(tokens.textPrimary)
-            Text("Manual")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(tokens.textSecondary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .background(tokens.bgFloating.opacity(0.78), in: Capsule())
-                .overlay {
-                    Capsule()
-                        .stroke(tokens.sectionBorder.opacity(0.9), lineWidth: 1)
+        HStack(alignment: .center, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Text("Daily Review")
+                        .font(.system(size: 23, weight: .bold, design: .rounded))
+                        .foregroundStyle(tokens.textPrimary)
+                    Text("Manual")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(tokens.textSecondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(tokens.bgFloating.opacity(0.82), in: Capsule())
+                        .overlay {
+                            Capsule()
+                                .stroke(tokens.sectionBorder.opacity(0.9), lineWidth: 1)
+                        }
                 }
-            Spacer()
-            Text("All Tasks: \(store.todoCount)")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(tokens.textSecondary)
+                Text("Review, clean up, and plan your next sprint of tasks.")
+                    .font(.caption)
+                    .foregroundStyle(tokens.textTertiary)
+            }
+            Spacer(minLength: 8)
+            metricPill(title: "All Tasks", value: store.todoCount)
         }
     }
 
     private var summaryPanel: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 8) {
-                summaryChip("Reviewed", value: touchedTaskIDs.count)
-                summaryChip("Done", value: completedCount)
-                summaryChip("Rescheduled", value: rescheduledCount)
-                summaryChip("My Day", value: addedToMyDayCount)
+                summaryChip("Reviewed", value: touchedTaskIDs.count, systemImage: "eye")
+                summaryChip("Done", value: completedCount, systemImage: "checkmark")
+                summaryChip("Rescheduled", value: rescheduledCount, systemImage: "calendar.badge.clock")
+                summaryChip("My Day", value: addedToMyDayCount, systemImage: "sun.max")
             }
 
             if let lastActionText {
-                Text(lastActionText)
-                    .font(.caption)
-                    .foregroundStyle(tokens.textSecondary)
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(tokens.accentTerracotta.opacity(0.85))
+                        .frame(width: 6, height: 6)
+                    Text(lastActionText)
+                        .font(.caption)
+                        .foregroundStyle(tokens.textSecondary)
+                        .lineLimit(1)
+                }
             }
         }
-        .padding(10)
-        .background(tokens.sectionBackground, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(tokens.sectionBackground)
+        )
         .overlay {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .stroke(tokens.sectionBorder, lineWidth: 1)
         }
     }
 
-    private func summaryChip(_ label: String, value: Int) -> some View {
+    private func summaryChip(_ label: String, value: Int, systemImage: String) -> some View {
         HStack(spacing: 6) {
+            Image(systemName: systemImage)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(tokens.textTertiary)
             Text(label)
                 .font(.caption2.weight(.semibold))
                 .foregroundStyle(tokens.textSecondary)
             Text("\(value)")
-                .font(.caption.weight(.semibold))
+                .font(.caption.weight(.bold))
                 .monospacedDigit()
                 .foregroundStyle(tokens.textPrimary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(tokens.bgFloating.opacity(0.95), in: Capsule())
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(tokens.bgFloating.opacity(0.82), in: Capsule())
+        .padding(.horizontal, 9)
+        .padding(.vertical, 6)
+        .background(tokens.bgFloating.opacity(0.72), in: Capsule())
         .overlay {
             Capsule()
-                .stroke(tokens.sectionBorder.opacity(0.9), lineWidth: 1)
+                .stroke(tokens.sectionBorder.opacity(0.85), lineWidth: 1)
+        }
+    }
+
+    private func metricPill(title: String, value: Int) -> some View {
+        HStack(spacing: 7) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(tokens.textSecondary)
+            Text("\(value)")
+                .font(.caption.weight(.bold))
+                .monospacedDigit()
+                .foregroundStyle(tokens.textPrimary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(tokens.bgFloating.opacity(0.9), in: Capsule())
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(tokens.sectionBackground, in: Capsule())
+        .overlay {
+            Capsule()
+                .stroke(tokens.sectionBorder, lineWidth: 1)
         }
     }
 
@@ -112,33 +155,36 @@ struct DailyReviewView: View {
     }
 
     private func reviewRow(_ todo: Todo) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(todo.title)
-                    .font(.body.weight(todo.isCompleted ? .regular : .semibold))
-                    .foregroundStyle(todo.isCompleted ? tokens.textTertiary : tokens.textPrimary)
+                    .font(.body.weight(todo.isCompleted ? .medium : .semibold))
+                    .foregroundStyle(todo.isCompleted ? tokens.textSecondary : tokens.textPrimary)
                     .strikethrough(todo.isCompleted)
-                    .lineLimit(1)
-                Spacer()
-                if todo.isCompleted {
-                    Text("Completed")
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(tokens.textTertiary)
-                }
+                    .lineLimit(2)
+
+                Spacer(minLength: 8)
+
+                Text(todo.isCompleted ? "Completed" : "Open")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(todo.isCompleted ? tokens.textTertiary : tokens.accentTerracotta)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(tokens.bgFloating.opacity(todo.isCompleted ? 0.55 : 0.9), in: Capsule())
             }
 
             HStack(spacing: 8) {
                 metaChip(label: todo.listId.flatMap(listName(for:)) ?? "Inbox")
                 metaChip(label: dueText(for: todo.dueDate))
                 if todo.isMyDay {
-                    metaChip(label: "My Day")
+                    metaChip(label: "My Day", accent: true)
                 }
-                Spacer()
+                Spacer(minLength: 8)
             }
 
             if !todo.isCompleted {
                 HStack(spacing: 8) {
-                    quickActionButton("Done", systemImage: "checkmark") {
+                    quickActionButton("Done", systemImage: "checkmark", emphasize: true) {
                         runAction(on: todo.id) {
                             try store.markComplete(todoId: todo.id)
                             completedCount += 1
@@ -146,7 +192,7 @@ struct DailyReviewView: View {
                         }
                     }
 
-                    quickActionButton("My Day", systemImage: "sun.max") {
+                    quickActionButton("My Day", systemImage: "sun.max", emphasize: false) {
                         runAction(on: todo.id) {
                             if !todo.isMyDay {
                                 try store.setMyDay(todoId: todo.id, isMyDay: true)
@@ -176,8 +222,8 @@ struct DailyReviewView: View {
                         }
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(tokens.textSecondary)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
+                        .padding(.horizontal, 11)
+                        .padding(.vertical, 7)
                         .background(tokens.bgFloating.opacity(0.8), in: Capsule())
                         .overlay {
                             Capsule()
@@ -188,40 +234,56 @@ struct DailyReviewView: View {
                 }
             }
         }
-        .padding(10)
-        .background(tokens.sectionBackground, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .padding(.horizontal, 12)
+        .padding(.vertical, 11)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(tokens.sectionBackground)
+        )
+        .overlay(alignment: .leading) {
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(todo.isCompleted ? tokens.textTertiary.opacity(0.45) : tokens.accentTerracotta.opacity(0.92))
+                .frame(width: 3)
+                .padding(.vertical, 9)
+                .padding(.leading, 5)
+        }
         .overlay {
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .stroke(tokens.sectionBorder, lineWidth: 1)
         }
+        .opacity(todo.isCompleted ? 0.72 : 1.0)
     }
 
-    private func quickActionButton(_ title: String, systemImage: String, action: @escaping () -> Void) -> some View {
+    private func quickActionButton(_ title: String, systemImage: String, emphasize: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             HStack(spacing: 6) {
                 Image(systemName: systemImage)
                 Text(title)
             }
             .font(.caption.weight(.semibold))
-            .foregroundStyle(tokens.textSecondary)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(tokens.bgFloating.opacity(0.8), in: Capsule())
+            .foregroundStyle(emphasize ? Color.white : tokens.textSecondary)
+            .padding(.horizontal, 11)
+            .padding(.vertical, 7)
+            .background((emphasize ? tokens.accentTerracotta.opacity(0.95) : tokens.bgFloating.opacity(0.8)), in: Capsule())
             .overlay {
                 Capsule()
-                    .stroke(tokens.sectionBorder.opacity(0.9), lineWidth: 1)
+                    .stroke(tokens.sectionBorder.opacity(emphasize ? 0.0 : 0.9), lineWidth: 1)
             }
         }
         .buttonStyle(.plain)
     }
 
-    private func metaChip(label: String) -> some View {
+    private func metaChip(label: String, accent: Bool = false) -> some View {
         Text(label)
             .font(.caption2.weight(.medium))
-            .foregroundStyle(tokens.textTertiary)
-            .padding(.horizontal, 7)
-            .padding(.vertical, 3)
-            .background(tokens.bgFloating.opacity(0.6), in: Capsule())
+            .foregroundStyle(accent ? tokens.accentTerracotta : tokens.textTertiary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(tokens.bgFloating.opacity(accent ? 0.82 : 0.62), in: Capsule())
+            .overlay {
+                Capsule()
+                    .stroke(tokens.sectionBorder.opacity(accent ? 0.35 : 0.0), lineWidth: 1)
+            }
     }
 
     private func dueText(for dueDate: Date?) -> String {

--- a/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
@@ -183,15 +183,6 @@ struct TaskDetailView: View {
                 .animation(MotionTokens.focusEase, value: isTitleFocused)
                 .animation(MotionTokens.validationEase, value: hasValidationError)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .overlay(alignment: .trailing) {
-                    LinearGradient(
-                        colors: [Color.clear, tokens.sectionBackground.opacity(0.78)],
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    )
-                    .frame(width: 18)
-                    .allowsHitTesting(false)
-                }
 
                 HStack(spacing: 10) {
                     Button {
@@ -229,12 +220,13 @@ struct TaskDetailView: View {
                 .padding(.vertical, 4)
                 .background(
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .fill(Color.white.opacity(0.035))
+                        .fill(Color.white.opacity(isTitleFocused ? 0.11 : 0.05))
                 )
                 .overlay {
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .stroke(tokens.sectionBorder.opacity(0.78), lineWidth: 1)
+                        .stroke(titleStrokeColor, lineWidth: titleStrokeWidth)
                 }
+                .animation(MotionTokens.focusEase, value: isTitleFocused)
             }
         }
         .padding(.horizontal, 12)


### PR DESCRIPTION
## Summary

This PR includes three focused improvements:

1. **Daily Review UI polish**
- Reworked visual hierarchy for the page header and metrics.
- Refined review cards with clearer status, metadata chips, and action affordances.
- Improved spacing and card readability while preserving existing review behaviors.

2. **Task detail header seam polish**
- Reduced the abrupt visual seam between title field and the right-side action cluster.
- Removed the trailing title fade overlay and aligned focus-state styling between both header segments.

3. **Quick Capture voice behavior update**
- Switched speech recognition to **English-only** (`en-US`), removing Chinese fallback lane.
- Updated reminder/status copy to English-only.
- On stop, if no final transcript is available but preview text exists, preview is now committed to input.
- Slightly relaxed silence auto-finalize threshold to improve practical capture success.

## Files Changed

- `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
- `macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift`
- `macos/TodoFocusMac/Sources/App/QuickCaptureService.swift`
- `macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCaptureView.swift`

## Verification

- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -quiet` (pass)
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS" -quiet` (pass)
