### PR TITLE
feat: Daily Review lightweight kanban (Open/Completed + time buckets)

### DIFF
--- a/docs/superpowers/issues/2026-03-31-daily-review-no-date-menubar-glass.md
+++ b/docs/superpowers/issues/2026-03-31-daily-review-no-date-menubar-glass.md
@@ -1,0 +1,17 @@
+# Daily Review No Date Column + Menubar Glass + Kanban Density
+
+## Scope
+- Add dedicated `No Date` column in Daily Review kanban (separate from `Later`).
+- Apply lightweight liquid-glass style to MenuBar panel (performance-first).
+- Reduce visual crowding inside kanban cards (action row spacing/fit).
+
+## Constraints
+- Keep macOS native behavior and low rendering overhead.
+- Avoid heavy animated blur stacks.
+- Preserve existing task actions and review semantics.
+
+## Acceptance Criteria
+- Open lane shows `Overdue / Today / Tomorrow / Later / No Date`.
+- `No Date` tasks do not appear in `Later`.
+- MenuBar panel gets subtle material/vibrancy feel without heavy effects.
+- Kanban card actions are readable and less cramped.

--- a/docs/superpowers/plans/2026-03-31-daily-review-no-date-menubar-glass.md
+++ b/docs/superpowers/plans/2026-03-31-daily-review-no-date-menubar-glass.md
@@ -1,0 +1,15 @@
+# Plan: No Date Column + Menubar Glass + Kanban Density
+
+## Implementation Steps
+1. Extend review bucket model with `noDate` and update board grouping.
+2. Keep `Later` only for dated tasks after tomorrow.
+3. Tune kanban card action layout to reduce crowding:
+   - Slightly smaller action controls
+   - Better wrapping/spacing behavior
+4. Add lightweight menu bar panel glass treatment using native material APIs.
+5. Add/adjust tests for no-date bucket behavior.
+6. Run full test/build verification.
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`

--- a/docs/superpowers/prs/2026-03-31-feat-112-daily-review-kanban-lite.md
+++ b/docs/superpowers/prs/2026-03-31-feat-112-daily-review-kanban-lite.md
@@ -8,15 +8,22 @@ Implements a lightweight Daily Review kanban layout focused on clarity and perfo
 - Sets `Completed` lane to collapsed by default with manual toggle.
 - Keeps existing task actions (`Done`, `My Day`, `Reschedule`) unchanged.
 - Adds tests for board grouping correctness.
+- Adds a dedicated `No Date` board column (separate from `Later`).
+- Reduces kanban card action crowding with compact adaptive action controls.
+- Applies subtle lightweight glass treatment to the menubar focus panel.
 
 Closes #112
+Closes #114
 
 ## Changed Files
 
 - `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
 - `macos/TodoFocusMac/Tests/CoreTests/DailyReviewViewTests.swift`
+- `macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift`
 - `docs/superpowers/plans/2026-03-31-daily-review-kanban-lite.md`
 - `docs/superpowers/issues/2026-03-31-daily-review-kanban-lite.md`
+- `docs/superpowers/plans/2026-03-31-daily-review-no-date-menubar-glass.md`
+- `docs/superpowers/issues/2026-03-31-daily-review-no-date-menubar-glass.md`
 
 ## Verification
 

--- a/macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift
+++ b/macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift
@@ -72,7 +72,14 @@ struct DeepFocusMenuBarPanel: View {
         }
         .padding(14)
         .frame(width: 340)
-        .background(themeTokens.panelBackground)
+        .background(
+            ZStack {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(themeTokens.panelBackground.opacity(0.72))
+            }
+        )
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .overlay {
             RoundedRectangle(cornerRadius: 14)

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -247,47 +247,7 @@ struct DailyReviewView: View {
             }
 
             if !isCompletedLane {
-                HStack(spacing: 8) {
-                    quickActionButton("Done", systemImage: "checkmark", emphasize: true) {
-                        runAction(on: todo.id) {
-                            try store.markComplete(todoId: todo.id)
-                            completedCount += 1
-                            lastActionText = "Marked done: \(todo.title)"
-                        }
-                    }
-
-                    quickActionButton("My Day", systemImage: "sun.max", emphasize: false) {
-                        runAction(on: todo.id) {
-                            if !todo.isMyDay {
-                                try store.setMyDay(todoId: todo.id, isMyDay: true)
-                                addedToMyDayCount += 1
-                                lastActionText = "Added to My Day: \(todo.title)"
-                            }
-                        }
-                    }
-
-                    Menu {
-                        Button("Today") { reschedule(todo: todo, to: .today) }
-                        Button("Tomorrow") { reschedule(todo: todo, to: .tomorrow) }
-                        Button("Next 7 Days") { reschedule(todo: todo, to: .next7) }
-                        Button("No Date") { reschedule(todo: todo, to: .none) }
-                    } label: {
-                        HStack(spacing: 6) {
-                            Image(systemName: "calendar.badge.clock")
-                            Text("Reschedule")
-                        }
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(tokens.textSecondary)
-                        .padding(.horizontal, 11)
-                        .padding(.vertical, 7)
-                        .background(tokens.bgFloating.opacity(0.8), in: Capsule())
-                        .overlay {
-                            Capsule()
-                                .stroke(tokens.sectionBorder.opacity(0.9), lineWidth: 1)
-                        }
-                    }
-                    .menuStyle(.borderlessButton)
-                }
+                cardActionsRow(todo)
             }
         }
         .padding(.horizontal, 10)
@@ -361,16 +321,78 @@ struct DailyReviewView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func quickActionButton(_ title: String, systemImage: String, emphasize: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
+    private func cardActionsRow(_ todo: Todo) -> some View {
+        ViewThatFits(in: .horizontal) {
             HStack(spacing: 6) {
+                doneActionButton(todo, compact: false)
+                myDayActionButton(todo, compact: false)
+                rescheduleMenu(todo, compact: false)
+            }
+
+            HStack(spacing: 6) {
+                doneActionButton(todo, compact: true)
+                myDayActionButton(todo, compact: true)
+                rescheduleMenu(todo, compact: true)
+            }
+        }
+    }
+
+    private func doneActionButton(_ todo: Todo, compact: Bool) -> some View {
+        quickActionButton(compact ? "Done" : "Done", systemImage: "checkmark", emphasize: true, compact: compact) {
+            runAction(on: todo.id) {
+                try store.markComplete(todoId: todo.id)
+                completedCount += 1
+                lastActionText = "Marked done: \(todo.title)"
+            }
+        }
+    }
+
+    private func myDayActionButton(_ todo: Todo, compact: Bool) -> some View {
+        quickActionButton(compact ? "My Day" : "My Day", systemImage: "sun.max", emphasize: false, compact: compact) {
+            runAction(on: todo.id) {
+                if !todo.isMyDay {
+                    try store.setMyDay(todoId: todo.id, isMyDay: true)
+                    addedToMyDayCount += 1
+                    lastActionText = "Added to My Day: \(todo.title)"
+                }
+            }
+        }
+    }
+
+    private func rescheduleMenu(_ todo: Todo, compact: Bool) -> some View {
+        Menu {
+            Button("Today") { reschedule(todo: todo, to: .today) }
+            Button("Tomorrow") { reschedule(todo: todo, to: .tomorrow) }
+            Button("Next 7 Days") { reschedule(todo: todo, to: .next7) }
+            Button("No Date") { reschedule(todo: todo, to: .none) }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: compact ? "calendar" : "calendar.badge.clock")
+                Text(compact ? "Date" : "Reschedule")
+            }
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(tokens.textSecondary)
+            .padding(.horizontal, compact ? 9 : 10)
+            .padding(.vertical, compact ? 5 : 6)
+            .background(tokens.bgFloating.opacity(0.8), in: Capsule())
+            .overlay {
+                Capsule()
+                    .stroke(tokens.sectionBorder.opacity(0.9), lineWidth: 1)
+            }
+        }
+        .menuStyle(.borderlessButton)
+    }
+
+    private func quickActionButton(_ title: String, systemImage: String, emphasize: Bool, compact: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: compact ? 4 : 6) {
                 Image(systemName: systemImage)
                 Text(title)
             }
             .font(.caption.weight(.semibold))
             .foregroundStyle(emphasize ? Color.white : tokens.textSecondary)
-            .padding(.horizontal, 11)
-            .padding(.vertical, 7)
+            .padding(.horizontal, compact ? 9 : 11)
+            .padding(.vertical, compact ? 5 : 7)
             .background((emphasize ? tokens.accentTerracotta.opacity(0.95) : tokens.bgFloating.opacity(0.8)), in: Capsule())
             .overlay {
                 Capsule()
@@ -447,6 +469,7 @@ extension DailyReviewView {
         case today
         case tomorrow
         case later
+        case noDate
 
         var id: String { rawValue }
 
@@ -456,6 +479,7 @@ extension DailyReviewView {
             case .today: return "Today"
             case .tomorrow: return "Tomorrow"
             case .later: return "Later"
+            case .noDate: return "No Date"
             }
         }
     }
@@ -508,7 +532,7 @@ extension DailyReviewView {
     }
 
     static func dueBucket(for dueDate: Date?, now: Date = Date(), calendar: Calendar = .current) -> ReviewTimeBucket {
-        guard let dueDate else { return .later }
+        guard let dueDate else { return .noDate }
         if calendar.isDate(dueDate, inSameDayAs: now) { return .today }
         let tomorrow = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
         if let tomorrow, calendar.isDate(dueDate, inSameDayAs: tomorrow) { return .tomorrow }

--- a/macos/TodoFocusMac/Tests/CoreTests/DailyReviewViewTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/DailyReviewViewTests.swift
@@ -50,8 +50,10 @@ final class DailyReviewViewTests: XCTestCase {
             Todo(id: "open-today", title: "Open Today", isCompleted: false, isImportant: false, isMyDay: false, dueDate: now, notes: "", listId: nil, launchResourcesRaw: ""),
             Todo(id: "open-tomorrow", title: "Open Tomorrow", isCompleted: false, isImportant: false, isMyDay: false, dueDate: tomorrow, notes: "", listId: nil, launchResourcesRaw: ""),
             Todo(id: "open-later", title: "Open Later", isCompleted: false, isImportant: false, isMyDay: false, dueDate: nextWeek, notes: "", listId: nil, launchResourcesRaw: ""),
+            Todo(id: "open-no-date", title: "Open No Date", isCompleted: false, isImportant: false, isMyDay: false, dueDate: nil, notes: "", listId: nil, launchResourcesRaw: ""),
             Todo(id: "completed-overdue", title: "Completed Overdue", isCompleted: true, isImportant: false, isMyDay: false, dueDate: yesterday, notes: "", listId: nil, launchResourcesRaw: ""),
-            Todo(id: "completed-later", title: "Completed Later", isCompleted: true, isImportant: false, isMyDay: false, dueDate: nextWeek, notes: "", listId: nil, launchResourcesRaw: "")
+            Todo(id: "completed-later", title: "Completed Later", isCompleted: true, isImportant: false, isMyDay: false, dueDate: nextWeek, notes: "", listId: nil, launchResourcesRaw: ""),
+            Todo(id: "completed-no-date", title: "Completed No Date", isCompleted: true, isImportant: false, isMyDay: false, dueDate: nil, notes: "", listId: nil, launchResourcesRaw: "")
         ]
 
         let board = DailyReviewView.buildBoard(todos, now: now, calendar: calendar)
@@ -60,8 +62,10 @@ final class DailyReviewViewTests: XCTestCase {
         XCTAssertEqual(board.openColumns.first(where: { $0.bucket == .today })?.todos.map(\.id), ["open-today"])
         XCTAssertEqual(board.openColumns.first(where: { $0.bucket == .tomorrow })?.todos.map(\.id), ["open-tomorrow"])
         XCTAssertEqual(board.openColumns.first(where: { $0.bucket == .later })?.todos.map(\.id), ["open-later"])
+        XCTAssertEqual(board.openColumns.first(where: { $0.bucket == .noDate })?.todos.map(\.id), ["open-no-date"])
 
         XCTAssertEqual(board.completedColumns.first(where: { $0.bucket == .overdue })?.todos.map(\.id), ["completed-overdue"])
         XCTAssertEqual(board.completedColumns.first(where: { $0.bucket == .later })?.todos.map(\.id), ["completed-later"])
+        XCTAssertEqual(board.completedColumns.first(where: { $0.bucket == .noDate })?.todos.map(\.id), ["completed-no-date"])
     }
 }


### PR DESCRIPTION
## Summary

Implements a lightweight Daily Review kanban layout focused on clarity and performance:

- Adds `DailyReviewBoardViewModel` to compute board data in one pass.
- Refactors Daily Review into two lanes: `Open` and `Completed`.
- Adds time buckets per lane: `Overdue`, `Today`, `Tomorrow`, `Later`.
- Sets `Completed` lane to collapsed by default with manual toggle.
- Keeps existing task actions (`Done`, `My Day`, `Reschedule`) unchanged.
- Adds tests for board grouping correctness.
- Adds a dedicated `No Date` board column (separate from `Later`).
- Reduces kanban card action crowding with compact adaptive action controls.
- Applies subtle lightweight glass treatment to the menubar focus panel.

Closes #112
Closes #114

## Changed Files

- `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
- `macos/TodoFocusMac/Tests/CoreTests/DailyReviewViewTests.swift`
- `macos/TodoFocusMac/Sources/Features/MenuBar/DeepFocusMenuBarPanel.swift`
- `docs/superpowers/plans/2026-03-31-daily-review-kanban-lite.md`
- `docs/superpowers/issues/2026-03-31-daily-review-kanban-lite.md`
- `docs/superpowers/plans/2026-03-31-daily-review-no-date-menubar-glass.md`
- `docs/superpowers/issues/2026-03-31-daily-review-no-date-menubar-glass.md`

## Verification

- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`
