### PR TITLE
fix: clean up Daily Review header and lane icon consistency

### DIFF
--- a/docs/superpowers/issues/2026-03-31-daily-review-header-cleanup.md
+++ b/docs/superpowers/issues/2026-03-31-daily-review-header-cleanup.md
@@ -1,0 +1,14 @@
+# Daily Review Header Cleanup
+
+## Problems
+1. The summary stats bar below the Daily Review title is visually noisy and redundant.
+2. `Open` lane header icon color is inconsistent with `Completed` lane styling.
+
+## Scope
+- Remove the summary stats strip from Daily Review.
+- Unify lane header icon color between `Open` and `Completed`.
+
+## Acceptance Criteria
+- No summary stats strip under the title.
+- Open and Completed lane headers share the same icon color style.
+- No regression in board grouping or card actions.

--- a/docs/superpowers/prs/2026-03-31-fix-115-daily-review-header-cleanup-main.md
+++ b/docs/superpowers/prs/2026-03-31-fix-115-daily-review-header-cleanup-main.md
@@ -1,0 +1,17 @@
+## Summary
+
+Daily Review header cleanup:
+- remove the summary stats strip under the page title
+- unify lane header icon styling so `Open` matches `Completed`
+
+Closes #115
+
+## Files
+- `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
+- `docs/superpowers/issues/2026-03-31-daily-review-header-cleanup.md`
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -22,16 +22,10 @@ struct DailyReviewView: View {
     @Environment(\.themeTokens) private var tokens
 
     @State private var boardViewModel = DailyReviewBoardViewModel()
-    @State private var touchedTaskIDs: Set<String> = []
-    @State private var completedCount: Int = 0
-    @State private var rescheduledCount: Int = 0
-    @State private var addedToMyDayCount: Int = 0
-    @State private var lastActionText: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             header
-            summaryPanel
 
             if store.todos.isEmpty {
                 emptyState
@@ -95,38 +89,6 @@ struct DailyReviewView: View {
         }
     }
 
-    private var summaryPanel: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 8) {
-                summaryChip("Reviewed", value: touchedTaskIDs.count, systemImage: "eye")
-                summaryChip("Done", value: completedCount, systemImage: "checkmark")
-                summaryChip("Rescheduled", value: rescheduledCount, systemImage: "calendar.badge.clock")
-                summaryChip("My Day", value: addedToMyDayCount, systemImage: "sun.max")
-            }
-
-            if let lastActionText {
-                HStack(spacing: 6) {
-                    Circle()
-                        .fill(tokens.accentTerracotta.opacity(0.85))
-                        .frame(width: 6, height: 6)
-                    Text(lastActionText)
-                        .font(.caption)
-                        .foregroundStyle(tokens.textSecondary)
-                        .lineLimit(1)
-                }
-            }
-        }
-        .padding(12)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(tokens.sectionBackground)
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(tokens.sectionBorder, lineWidth: 1)
-        }
-    }
-
     private func laneSection(
         title: String,
         systemImage: String,
@@ -143,7 +105,7 @@ struct DailyReviewView: View {
                 HStack(spacing: 8) {
                     Image(systemName: systemImage)
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(isCompletedLane ? tokens.textSecondary : tokens.accentTerracotta)
+                        .foregroundStyle(tokens.textSecondary)
                     Text(title)
                         .font(.headline.weight(.semibold))
                         .foregroundStyle(tokens.textPrimary)
@@ -262,31 +224,6 @@ struct DailyReviewView: View {
         }
     }
 
-    private func summaryChip(_ label: String, value: Int, systemImage: String) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: systemImage)
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(tokens.textTertiary)
-            Text(label)
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(tokens.textSecondary)
-            Text("\(value)")
-                .font(.caption.weight(.bold))
-                .monospacedDigit()
-                .foregroundStyle(tokens.textPrimary)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(tokens.bgFloating.opacity(0.95), in: Capsule())
-        }
-        .padding(.horizontal, 9)
-        .padding(.vertical, 6)
-        .background(tokens.bgFloating.opacity(0.72), in: Capsule())
-        .overlay {
-            Capsule()
-                .stroke(tokens.sectionBorder.opacity(0.85), lineWidth: 1)
-        }
-    }
-
     private func metricPill(title: String, value: Int) -> some View {
         HStack(spacing: 7) {
             Text(title)
@@ -341,8 +278,6 @@ struct DailyReviewView: View {
         quickActionButton(compact ? "Done" : "Done", systemImage: "checkmark", emphasize: true, compact: compact) {
             runAction(on: todo.id) {
                 try store.markComplete(todoId: todo.id)
-                completedCount += 1
-                lastActionText = "Marked done: \(todo.title)"
             }
         }
     }
@@ -352,8 +287,6 @@ struct DailyReviewView: View {
             runAction(on: todo.id) {
                 if !todo.isMyDay {
                     try store.setMyDay(todoId: todo.id, isMyDay: true)
-                    addedToMyDayCount += 1
-                    lastActionText = "Added to My Day: \(todo.title)"
                 }
             }
         }
@@ -426,9 +359,8 @@ struct DailyReviewView: View {
     private func runAction(on todoID: String, _ action: () throws -> Void) {
         do {
             try action()
-            touchedTaskIDs.insert(todoID)
         } catch {
-            lastActionText = "Action failed. Please retry."
+            _ = todoID
         }
     }
 
@@ -457,8 +389,6 @@ struct DailyReviewView: View {
                 date = nil
             }
             try store.setDueDate(todoId: todo.id, date: date)
-            rescheduledCount += 1
-            lastActionText = "Rescheduled: \(todo.title)"
         }
     }
 }


### PR DESCRIPTION
## Summary

Daily Review header cleanup:
- remove the summary stats strip under the page title
- unify lane header icon styling so `Open` matches `Completed`

Closes #115

## Files
- `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
- `docs/superpowers/issues/2026-03-31-daily-review-header-cleanup.md`

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`
