### PR TITLE
fix: polish Daily Review action density and Open lane title color

### DIFF
--- a/docs/superpowers/issues/2026-03-31-daily-review-kanban-density-and-open-title-color.md
+++ b/docs/superpowers/issues/2026-03-31-daily-review-kanban-density-and-open-title-color.md
@@ -1,0 +1,15 @@
+# Daily Review Kanban Density + Open Title Color
+
+## Problems
+1. Kanban card action row is still visually crowded in narrow columns.
+2. `Open` lane title color should match `Completed` title color (white text style).
+
+## Scope
+- Improve spacing and compact behavior for the action row in Daily Review cards.
+- Keep all existing actions (`Done`, `My Day`, `Date`) intact.
+- Set `Open` title text style to match `Completed` title text style.
+
+## Acceptance Criteria
+- Action row appears less crowded in regular usage widths.
+- No clipping/overlap in card actions.
+- `Open` and `Completed` title text styles are visually consistent.

--- a/docs/superpowers/prs/2026-03-31-fix-119-daily-review-density-and-open-title-color.md
+++ b/docs/superpowers/prs/2026-03-31-fix-119-daily-review-density-and-open-title-color.md
@@ -1,0 +1,17 @@
+## Summary
+
+Daily Review UI polish follow-up:
+- reduce action-row crowding by adding a two-row compact fallback layout
+- make `Open` lane title text match `Completed` style (white text)
+
+Closes #119
+
+## Files
+- `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
+- `docs/superpowers/issues/2026-03-31-daily-review-kanban-density-and-open-title-color.md`
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -108,7 +108,7 @@ struct DailyReviewView: View {
                         .foregroundStyle(tokens.textSecondary)
                     Text(title)
                         .font(.headline.weight(.semibold))
-                        .foregroundStyle(tokens.textPrimary)
+                        .foregroundStyle(Color.white)
                     Text("\(columns.reduce(0) { $0 + $1.todos.count })")
                         .font(.caption.weight(.bold))
                         .monospacedDigit()
@@ -270,6 +270,18 @@ struct DailyReviewView: View {
                 doneActionButton(todo, compact: true)
                 myDayActionButton(todo, compact: true)
                 rescheduleMenu(todo, compact: true)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    doneActionButton(todo, compact: true)
+                    myDayActionButton(todo, compact: true)
+                    Spacer(minLength: 0)
+                }
+                HStack(spacing: 6) {
+                    rescheduleMenu(todo, compact: true)
+                    Spacer(minLength: 0)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Daily Review UI polish follow-up:
- reduce action-row crowding by adding a two-row compact fallback layout
- make `Open` lane title text match `Completed` style (white text)

Closes #119

## Files
- `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
- `docs/superpowers/issues/2026-03-31-daily-review-kanban-density-and-open-title-color.md`

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`
