### PR TITLE
fix: Daily Review kanban column multi-task visibility and scroll

### DIFF
--- a/docs/superpowers/issues/2026-03-31-daily-review-column-scroll-bug.md
+++ b/docs/superpowers/issues/2026-03-31-daily-review-column-scroll-bug.md
@@ -1,0 +1,16 @@
+# Daily Review Column Scroll Bug
+
+## Bug
+In Daily Review kanban columns, counts can show multiple tasks while only one card is visible, with no way to scroll to the rest in some window sizes/layout states.
+
+## Root Cause (expected)
+Column content uses a plain stack without guaranteed per-column vertical scrolling when height is constrained.
+
+## Fix Scope
+- Make column task content explicitly vertically scrollable.
+- Keep horizontal lane scrolling behavior unchanged.
+- Preserve current card layout/actions.
+
+## Acceptance Criteria
+- If a column has multiple tasks, all tasks are reachable via scroll.
+- No regression in lane switching, grouping, or actions.

--- a/docs/superpowers/plans/2026-03-31-daily-review-column-scroll-bug-fix.md
+++ b/docs/superpowers/plans/2026-03-31-daily-review-column-scroll-bug-fix.md
@@ -1,0 +1,6 @@
+# Plan: Daily Review Column Scroll Bug Fix
+
+1. Add explicit vertical scroll container inside each kanban column body.
+2. Apply a sensible max column content height so overflow is scrollable instead of clipped.
+3. Keep empty-state rendering unchanged.
+4. Verify with full test + release build.

--- a/docs/superpowers/prs/2026-03-31-fix-121-daily-review-column-scroll-bug.md
+++ b/docs/superpowers/prs/2026-03-31-fix-121-daily-review-column-scroll-bug.md
@@ -1,0 +1,20 @@
+## Summary
+
+Fixes a serious Daily Review kanban bug where a column can show count > 1 but only one task card is visible with no scroll path.
+
+### Change
+- Add explicit vertical scrolling to per-column task content.
+- Cap column content height so overflow becomes scrollable instead of clipped.
+
+Closes #121
+
+## Files
+- `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
+- `docs/superpowers/issues/2026-03-31-daily-review-column-scroll-bug.md`
+- `docs/superpowers/plans/2026-03-31-daily-review-column-scroll-bug-fix.md`
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -172,11 +172,15 @@ struct DailyReviewView: View {
                     .padding(.vertical, 10)
                     .background(tokens.bgFloating.opacity(0.35), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
             } else {
-                LazyVStack(spacing: 8) {
-                    ForEach(column.todos) { todo in
-                        reviewCard(todo, isCompletedLane: isCompletedLane)
+                ScrollView(.vertical) {
+                    LazyVStack(spacing: 8) {
+                        ForEach(column.todos) { todo in
+                            reviewCard(todo, isCompletedLane: isCompletedLane)
+                        }
                     }
                 }
+                .scrollIndicators(.visible)
+                .frame(maxHeight: 280)
             }
         }
         .padding(10)


### PR DESCRIPTION
## Summary

Fixes a serious Daily Review kanban bug where a column can show count > 1 but only one task card is visible with no scroll path.

### Change
- Add explicit vertical scrolling to per-column task content.
- Cap column content height so overflow becomes scrollable instead of clipped.

Closes #121

## Files
- `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
- `docs/superpowers/issues/2026-03-31-daily-review-column-scroll-bug.md`
- `docs/superpowers/plans/2026-03-31-daily-review-column-scroll-bug-fix.md`

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`
