### PR TITLE
Fix #125: Daily Review page scroll + per-column collapse

### DIFF
--- a/docs/superpowers/issues/2026-03-31-daily-review-global-scroll-and-column-collapse.md
+++ b/docs/superpowers/issues/2026-03-31-daily-review-global-scroll-and-column-collapse.md
@@ -1,0 +1,23 @@
+# Daily Review: keep page-level scrolling + add per-column collapse
+
+## Problem
+Current Daily Review behavior after scroll bug fixes no longer provides the desired interaction model:
+- Users want page-level scroll behavior (whole review page scrollable).
+- Users also need expand/collapse controls not only for Completed lane, but also for each time bucket column.
+
+## Root-Cause Notes
+- To avoid the previous nested-scroll clipping bug, column inner vertical scroll was removed.
+- This fixed visibility, but reduced interaction flexibility because columns are always fully expanded.
+- Existing collapse control only applies to Completed lane as a whole.
+
+## Requested Behavior
+1. Keep page-level vertical scrolling as the primary scroll container.
+2. Keep Completed lane-level collapse/expand.
+3. Add per-column collapse/expand for both Open and Completed lanes.
+4. Keep columns naturally expanded by default (no inner vertical scroller).
+
+## Success Criteria
+- All columns can be individually collapsed/expanded.
+- Completed lane can still be collapsed/expanded as a whole.
+- No regression of the prior "multiple tasks but only one visible" bug.
+- Daily Review tests still pass.

--- a/docs/superpowers/plans/2026-03-31-daily-review-global-scroll-and-column-collapse.md
+++ b/docs/superpowers/plans/2026-03-31-daily-review-global-scroll-and-column-collapse.md
@@ -1,0 +1,47 @@
+# Daily Review Global Scroll + Column Collapse Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Daily Review page-level scrolling while adding per-column expand/collapse controls, without reintroducing clipped card visibility regressions.
+
+**Architecture:** Extend `DailyReviewBoardViewModel` with lane-aware per-bucket collapse state. Preserve existing Completed-lane collapse. Render column headers as interactive toggles that only hide/show that column’s card stack.
+
+**Tech Stack:** SwiftUI, Observation, XCTest
+
+---
+
+### Task 1: Workflow setup
+
+**Files:**
+- Modify: `docs/superpowers/issues/2026-03-31-daily-review-global-scroll-and-column-collapse.md`
+
+- [ ] Create GitHub issue from issue doc
+- [ ] Create fix branch from latest main
+
+### Task 2: Add per-column collapse state + UI interactions
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
+
+- [ ] Add lane-aware per-bucket collapse state in `DailyReviewBoardViewModel`
+- [ ] Add APIs to read/toggle per-column collapse
+- [ ] Render each column header as collapse toggle with chevron affordance
+- [ ] Keep page-level scroll as primary vertical scroll
+- [ ] Keep existing Completed lane-level collapse behavior
+
+### Task 3: Regression tests
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Tests/CoreTests/DailyReviewViewTests.swift`
+
+- [ ] Add tests for per-column collapse state behavior
+- [ ] Keep existing board bucket tests green
+
+### Task 4: Verify + PR
+
+**Files:**
+- Create: `docs/superpowers/prs/2026-03-31-fix-<issue>-daily-review-global-scroll-and-column-collapse.md`
+
+- [ ] Run full tests
+- [ ] Run Release build
+- [ ] Commit, push, open PR with `Closes #<issue>`

--- a/docs/superpowers/prs/2026-03-31-fix-125-daily-review-global-scroll-and-column-collapse.md
+++ b/docs/superpowers/prs/2026-03-31-fix-125-daily-review-global-scroll-and-column-collapse.md
@@ -1,0 +1,29 @@
+## Summary
+- Kept Daily Review page-level vertical scrolling as the primary scroll container.
+- Added per-column collapse/expand for all time buckets in both Open and Completed lanes.
+- Preserved existing Completed lane-level collapse/expand behavior.
+- Kept column content naturally expanded when open (no inner vertical card scroller).
+
+## Changes
+- `DailyReviewBoardViewModel`
+  - Added lane-aware collapsed bucket sets:
+    - `openCollapsedBuckets`
+    - `completedCollapsedBuckets`
+  - Added methods:
+    - `isColumnCollapsed(bucket:isCompletedLane:)`
+    - `toggleColumn(bucket:isCompletedLane:)`
+- `DailyReviewView`
+  - Converted each column header into a plain button with chevron indicator.
+  - Column body now hides/shows based on per-column collapse state.
+  - No nested vertical list scroller was introduced; page scroll remains at outer level.
+- `DailyReviewViewTests`
+  - Added coverage for lane-level and per-column collapse independence.
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -derivedDataPath "/tmp/todofocus-deriveddata-test" -destination "platform=macOS"`
+  - Result: `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "/tmp/todofocus-deriveddata-build" -destination "platform=macOS"`
+  - Result: `** BUILD SUCCEEDED **`
+
+## Issue
+Closes #125

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -6,6 +6,8 @@ import Observation
 final class DailyReviewBoardViewModel {
     var board: DailyReviewView.ReviewBoard = .empty
     var isCompletedCollapsed: Bool = true
+    var openCollapsedBuckets: Set<DailyReviewView.ReviewTimeBucket> = []
+    var completedCollapsedBuckets: Set<DailyReviewView.ReviewTimeBucket> = []
 
     func recompute(todos: [Todo], now: Date = Date(), calendar: Calendar = .current) {
         board = DailyReviewView.buildBoard(todos, now: now, calendar: calendar)
@@ -13,6 +15,30 @@ final class DailyReviewBoardViewModel {
 
     func toggleCompletedLane() {
         isCompletedCollapsed.toggle()
+    }
+
+    func isColumnCollapsed(bucket: DailyReviewView.ReviewTimeBucket, isCompletedLane: Bool) -> Bool {
+        if isCompletedLane {
+            return completedCollapsedBuckets.contains(bucket)
+        }
+        return openCollapsedBuckets.contains(bucket)
+    }
+
+    func toggleColumn(bucket: DailyReviewView.ReviewTimeBucket, isCompletedLane: Bool) {
+        if isCompletedLane {
+            if completedCollapsedBuckets.contains(bucket) {
+                completedCollapsedBuckets.remove(bucket)
+            } else {
+                completedCollapsedBuckets.insert(bucket)
+            }
+            return
+        }
+
+        if openCollapsedBuckets.contains(bucket) {
+            openCollapsedBuckets.remove(bucket)
+        } else {
+            openCollapsedBuckets.insert(bucket)
+        }
     }
 }
 
@@ -157,32 +183,45 @@ struct DailyReviewView: View {
     }
 
     private func reviewColumnView(_ column: ReviewColumn, isCompletedLane: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 6) {
-                Text(column.bucket.title)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(tokens.textPrimary)
-                Text("\(column.todos.count)")
-                    .font(.caption.weight(.bold))
-                    .monospacedDigit()
-                    .foregroundStyle(tokens.textSecondary)
-                    .padding(.horizontal, 7)
-                    .padding(.vertical, 2)
-                    .background(tokens.bgFloating.opacity(0.8), in: Capsule())
-            }
+        let isColumnCollapsed = boardViewModel.isColumnCollapsed(bucket: column.bucket, isCompletedLane: isCompletedLane)
 
-            if column.todos.isEmpty {
-                Text("No tasks")
-                    .font(.caption)
-                    .foregroundStyle(tokens.textTertiary)
-                    .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 10)
-                    .background(tokens.bgFloating.opacity(0.35), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-            } else {
-                LazyVStack(spacing: 8) {
-                    ForEach(column.todos) { todo in
-                        reviewCard(todo, isCompletedLane: isCompletedLane)
+        return VStack(alignment: .leading, spacing: 8) {
+            Button {
+                boardViewModel.toggleColumn(bucket: column.bucket, isCompletedLane: isCompletedLane)
+            } label: {
+                HStack(spacing: 6) {
+                    Text(column.bucket.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(tokens.textPrimary)
+                    Text("\(column.todos.count)")
+                        .font(.caption.weight(.bold))
+                        .monospacedDigit()
+                        .foregroundStyle(tokens.textSecondary)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 2)
+                        .background(tokens.bgFloating.opacity(0.8), in: Capsule())
+                    Spacer(minLength: 6)
+                    Image(systemName: isColumnCollapsed ? "chevron.down" : "chevron.up")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(tokens.textSecondary)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if !isColumnCollapsed {
+                if column.todos.isEmpty {
+                    Text("No tasks")
+                        .font(.caption)
+                        .foregroundStyle(tokens.textTertiary)
+                        .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 10)
+                        .background(tokens.bgFloating.opacity(0.35), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                } else {
+                    LazyVStack(spacing: 8) {
+                        ForEach(column.todos) { todo in
+                            reviewCard(todo, isCompletedLane: isCompletedLane)
+                        }
                     }
                 }
             }

--- a/macos/TodoFocusMac/Tests/CoreTests/DailyReviewViewTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/DailyReviewViewTests.swift
@@ -68,4 +68,27 @@ final class DailyReviewViewTests: XCTestCase {
         XCTAssertEqual(board.completedColumns.first(where: { $0.bucket == .later })?.todos.map(\.id), ["completed-later"])
         XCTAssertEqual(board.completedColumns.first(where: { $0.bucket == .noDate })?.todos.map(\.id), ["completed-no-date"])
     }
+
+    func testViewModelSupportsLaneAndPerColumnCollapseIndependently() {
+        let viewModel = DailyReviewBoardViewModel()
+
+        XCTAssertTrue(viewModel.isCompletedCollapsed)
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: false))
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: true))
+
+        viewModel.toggleCompletedLane()
+        XCTAssertFalse(viewModel.isCompletedCollapsed)
+
+        viewModel.toggleColumn(bucket: .today, isCompletedLane: false)
+        XCTAssertTrue(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: false))
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: true))
+
+        viewModel.toggleColumn(bucket: .today, isCompletedLane: true)
+        XCTAssertTrue(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: true))
+
+        viewModel.toggleColumn(bucket: .today, isCompletedLane: false)
+        viewModel.toggleColumn(bucket: .today, isCompletedLane: true)
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: false))
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: true))
+    }
 }


### PR DESCRIPTION
## Summary
- Kept Daily Review page-level vertical scrolling as the primary scroll container.
- Added per-column collapse/expand for all time buckets in both Open and Completed lanes.
- Preserved existing Completed lane-level collapse/expand behavior.
- Kept column content naturally expanded when open (no inner vertical card scroller).

## Changes
- `DailyReviewBoardViewModel`
  - Added lane-aware collapsed bucket sets:
    - `openCollapsedBuckets`
    - `completedCollapsedBuckets`
  - Added methods:
    - `isColumnCollapsed(bucket:isCompletedLane:)`
    - `toggleColumn(bucket:isCompletedLane:)`
- `DailyReviewView`
  - Converted each column header into a plain button with chevron indicator.
  - Column body now hides/shows based on per-column collapse state.
  - No nested vertical list scroller was introduced; page scroll remains at outer level.
- `DailyReviewViewTests`
  - Added coverage for lane-level and per-column collapse independence.

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -derivedDataPath "/tmp/todofocus-deriveddata-test" -destination "platform=macOS"`
  - Result: `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "/tmp/todofocus-deriveddata-build" -destination "platform=macOS"`
  - Result: `** BUILD SUCCEEDED **`

## Issue
Closes #125
