### PR TITLE
Fix #127: Daily Review multi-card visibility and collapse scope

### DIFF
--- a/docs/superpowers/issues/2026-04-01-daily-review-multi-card-visibility-and-collapse-scope.md
+++ b/docs/superpowers/issues/2026-04-01-daily-review-multi-card-visibility-and-collapse-scope.md
@@ -1,0 +1,25 @@
+# Daily Review: multi-card visibility + collapse scope fix
+
+## Reported Problems
+1. In a bucket with count > 1 (e.g., Today: 2), only one task card is visible.
+2. Overdue collapse control behavior is perceived as affecting broader column scope than intended.
+
+## Systematic Debugging Evidence
+- Data bucketing logic is correct (`buildBoard` counts/todos are populated and tests pass for grouping).
+- No explicit per-column height cap exists in `DailyReviewView`.
+- Current UI uses nested scroll composition with lazy stacks:
+  - Horizontal `ScrollView` + `LazyHStack` for columns
+  - `LazyVStack` for cards inside each column
+- This composition can cause unstable child realization/layout in non-virtualization-sized kanban sections, matching the symptom "count says 2 but only one rendered".
+- Column collapse is currently toggled by tapping the full column header row, which can feel over-broad and accidental.
+
+## Fix Scope
+- Replace lane column container from `LazyHStack` to deterministic `HStack`.
+- Replace per-column card stack from `LazyVStack` to deterministic `VStack`.
+- Tighten collapse trigger to explicit chevron button.
+- Harden collapse state keying using `lane + bucket` identity and add regression tests for scope isolation.
+
+## Success Criteria
+- Bucket with 2+ tasks renders all cards.
+- Overdue collapse only affects the intended column in the intended lane.
+- Existing lane collapse (Completed) still works.

--- a/docs/superpowers/plans/2026-04-01-daily-review-multi-card-visibility-and-collapse-scope.md
+++ b/docs/superpowers/plans/2026-04-01-daily-review-multi-card-visibility-and-collapse-scope.md
@@ -1,0 +1,47 @@
+# Daily Review Multi-Card Visibility + Collapse Scope Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Daily Review so all cards in a bucket render reliably and column collapse control affects only intended scope.
+
+**Architecture:** Use deterministic stacks (`HStack/VStack`) in Daily Review kanban rendering to avoid lazy realization artifacts in nested-scroll context. Represent collapse state by lane+bucket key. Restrict toggle interaction to explicit chevron control.
+
+**Tech Stack:** SwiftUI, Observation, XCTest
+
+---
+
+### Task 1: Workflow artifacts
+
+**Files:**
+- Create: `docs/superpowers/issues/2026-04-01-daily-review-multi-card-visibility-and-collapse-scope.md`
+- Create: `docs/superpowers/plans/2026-04-01-daily-review-multi-card-visibility-and-collapse-scope.md`
+
+- [ ] Create GitHub issue from issue doc
+- [ ] Create branch from latest main
+
+### Task 2: Rendering and interaction fix
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
+
+- [ ] Replace `LazyHStack` with `HStack` for columns
+- [ ] Replace per-column `LazyVStack` with `VStack` for cards
+- [ ] Make column collapse trigger explicit chevron button
+- [ ] Key collapse state by lane+bucket
+
+### Task 3: Regression tests
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Tests/CoreTests/DailyReviewViewTests.swift`
+
+- [ ] Add test for multi-card in same bucket count/content integrity
+- [ ] Add test for collapse scope isolation (open overdue toggle does not affect open today / completed overdue)
+
+### Task 4: Verification and PR
+
+**Files:**
+- Create: `docs/superpowers/prs/2026-04-01-fix-<issue>-daily-review-multi-card-visibility-and-collapse-scope.md`
+
+- [ ] Run full tests
+- [ ] Run release build
+- [ ] Commit + push + open PR with `Closes #<issue>`

--- a/docs/superpowers/prs/2026-04-01-fix-127-daily-review-multi-card-visibility-and-collapse-scope.md
+++ b/docs/superpowers/prs/2026-04-01-fix-127-daily-review-multi-card-visibility-and-collapse-scope.md
@@ -1,0 +1,29 @@
+## Summary
+- Fixed Daily Review bucket rendering so multiple tasks in the same bucket reliably display.
+- Tightened column collapse interaction scope so toggle intent is explicit and lane-isolated.
+
+## Root Cause
+- The kanban lane used lazy stacks in a nested-scroll layout (`LazyHStack` for columns + `LazyVStack` for cards), which can produce unstable child realization/height behavior in this UI shape.
+- Column collapse was toggled by tapping the full header row, which made scope feel too broad and accidental.
+
+## Changes
+- `DailyReviewView`
+  - Replaced lane columns container from `LazyHStack` to `HStack`.
+  - Replaced per-column cards stack from `LazyVStack` to `VStack`.
+  - Changed per-column collapse trigger from full-header tap to explicit chevron button.
+  - Hardened collapse identity by keying state with `lane + bucket` (`ReviewColumnCollapseKey`).
+- `DailyReviewViewTests`
+  - Updated collapse tests to lane-aware API.
+  - Added `testColumnCollapseScopeIsolationForOverdue`.
+  - Added `testBuildBoardKeepsAllTodosInSameBucket`.
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -derivedDataPath "/tmp/todofocus-dd-127-target" -destination "platform=macOS" -only-testing:CoreTests/DailyReviewViewTests`
+  - Result: `** TEST SUCCEEDED **`
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -derivedDataPath "/tmp/todofocus-dd-127-fulltest" -destination "platform=macOS"`
+  - Result: `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "/tmp/todofocus-dd-127-build" -destination "platform=macOS"`
+  - Result: `** BUILD SUCCEEDED **`
+
+## Issue
+Closes #127

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -6,8 +6,7 @@ import Observation
 final class DailyReviewBoardViewModel {
     var board: DailyReviewView.ReviewBoard = .empty
     var isCompletedCollapsed: Bool = true
-    var openCollapsedBuckets: Set<DailyReviewView.ReviewTimeBucket> = []
-    var completedCollapsedBuckets: Set<DailyReviewView.ReviewTimeBucket> = []
+    private var collapsedColumns: Set<DailyReviewView.ReviewColumnCollapseKey> = []
 
     func recompute(todos: [Todo], now: Date = Date(), calendar: Calendar = .current) {
         board = DailyReviewView.buildBoard(todos, now: now, calendar: calendar)
@@ -17,27 +16,16 @@ final class DailyReviewBoardViewModel {
         isCompletedCollapsed.toggle()
     }
 
-    func isColumnCollapsed(bucket: DailyReviewView.ReviewTimeBucket, isCompletedLane: Bool) -> Bool {
-        if isCompletedLane {
-            return completedCollapsedBuckets.contains(bucket)
-        }
-        return openCollapsedBuckets.contains(bucket)
+    func isColumnCollapsed(bucket: DailyReviewView.ReviewTimeBucket, lane: DailyReviewView.ReviewLane) -> Bool {
+        collapsedColumns.contains(.init(lane: lane, bucket: bucket))
     }
 
-    func toggleColumn(bucket: DailyReviewView.ReviewTimeBucket, isCompletedLane: Bool) {
-        if isCompletedLane {
-            if completedCollapsedBuckets.contains(bucket) {
-                completedCollapsedBuckets.remove(bucket)
-            } else {
-                completedCollapsedBuckets.insert(bucket)
-            }
-            return
-        }
-
-        if openCollapsedBuckets.contains(bucket) {
-            openCollapsedBuckets.remove(bucket)
+    func toggleColumn(bucket: DailyReviewView.ReviewTimeBucket, lane: DailyReviewView.ReviewLane) {
+        let key = DailyReviewView.ReviewColumnCollapseKey(lane: lane, bucket: bucket)
+        if collapsedColumns.contains(key) {
+            collapsedColumns.remove(key)
         } else {
-            openCollapsedBuckets.insert(bucket)
+            collapsedColumns.insert(key)
         }
     }
 }
@@ -66,6 +54,7 @@ struct DailyReviewView: View {
                             title: "Open",
                             systemImage: "tray",
                             columns: boardViewModel.board.openColumns,
+                            lane: .open,
                             collapsed: false,
                             isCompletedLane: false
                         )
@@ -74,6 +63,7 @@ struct DailyReviewView: View {
                             title: "Completed",
                             systemImage: "checkmark.circle",
                             columns: boardViewModel.board.completedColumns,
+                            lane: .completed,
                             collapsed: boardViewModel.isCompletedCollapsed,
                             isCompletedLane: true
                         )
@@ -127,6 +117,7 @@ struct DailyReviewView: View {
         title: String,
         systemImage: String,
         columns: [ReviewColumn],
+        lane: ReviewLane,
         collapsed: Bool,
         isCompletedLane: Bool
     ) -> some View {
@@ -170,9 +161,9 @@ struct DailyReviewView: View {
 
             if !collapsed {
                 ScrollView(.horizontal) {
-                    LazyHStack(alignment: .top, spacing: 10) {
+                    HStack(alignment: .top, spacing: 10) {
                         ForEach(columns) { column in
-                            reviewColumnView(column, isCompletedLane: isCompletedLane)
+                            reviewColumnView(column, lane: lane, isCompletedLane: isCompletedLane)
                         }
                     }
                     .padding(.vertical, 2)
@@ -182,31 +173,33 @@ struct DailyReviewView: View {
         }
     }
 
-    private func reviewColumnView(_ column: ReviewColumn, isCompletedLane: Bool) -> some View {
-        let isColumnCollapsed = boardViewModel.isColumnCollapsed(bucket: column.bucket, isCompletedLane: isCompletedLane)
+    private func reviewColumnView(_ column: ReviewColumn, lane: ReviewLane, isCompletedLane: Bool) -> some View {
+        let isColumnCollapsed = boardViewModel.isColumnCollapsed(bucket: column.bucket, lane: lane)
 
         return VStack(alignment: .leading, spacing: 8) {
-            Button {
-                boardViewModel.toggleColumn(bucket: column.bucket, isCompletedLane: isCompletedLane)
-            } label: {
-                HStack(spacing: 6) {
-                    Text(column.bucket.title)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(tokens.textPrimary)
-                    Text("\(column.todos.count)")
-                        .font(.caption.weight(.bold))
-                        .monospacedDigit()
-                        .foregroundStyle(tokens.textSecondary)
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, 2)
-                        .background(tokens.bgFloating.opacity(0.8), in: Capsule())
-                    Spacer(minLength: 6)
+            HStack(spacing: 6) {
+                Text(column.bucket.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(tokens.textPrimary)
+                Text("\(column.todos.count)")
+                    .font(.caption.weight(.bold))
+                    .monospacedDigit()
+                    .foregroundStyle(tokens.textSecondary)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 2)
+                    .background(tokens.bgFloating.opacity(0.8), in: Capsule())
+                Spacer(minLength: 6)
+                Button {
+                    boardViewModel.toggleColumn(bucket: column.bucket, lane: lane)
+                } label: {
                     Image(systemName: isColumnCollapsed ? "chevron.down" : "chevron.up")
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(tokens.textSecondary)
+                        .frame(width: 20, height: 20)
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel("\(column.bucket.title) \(isColumnCollapsed ? "Expand" : "Collapse")")
             }
-            .buttonStyle(.plain)
 
             if !isColumnCollapsed {
                 if column.todos.isEmpty {
@@ -218,7 +211,7 @@ struct DailyReviewView: View {
                         .padding(.vertical, 10)
                         .background(tokens.bgFloating.opacity(0.35), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
                 } else {
-                    LazyVStack(spacing: 8) {
+                    VStack(spacing: 8) {
                         ForEach(column.todos) { todo in
                             reviewCard(todo, isCompletedLane: isCompletedLane)
                         }
@@ -487,6 +480,16 @@ struct DailyReviewView: View {
 }
 
 extension DailyReviewView {
+    enum ReviewLane: String {
+        case open
+        case completed
+    }
+
+    struct ReviewColumnCollapseKey: Hashable {
+        let lane: ReviewLane
+        let bucket: ReviewTimeBucket
+    }
+
     enum ReviewTimeBucket: String, CaseIterable, Identifiable {
         case overdue
         case today

--- a/macos/TodoFocusMac/Tests/CoreTests/DailyReviewViewTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/DailyReviewViewTests.swift
@@ -73,22 +73,49 @@ final class DailyReviewViewTests: XCTestCase {
         let viewModel = DailyReviewBoardViewModel()
 
         XCTAssertTrue(viewModel.isCompletedCollapsed)
-        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: false))
-        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: true))
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, lane: .open))
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, lane: .completed))
 
         viewModel.toggleCompletedLane()
         XCTAssertFalse(viewModel.isCompletedCollapsed)
 
-        viewModel.toggleColumn(bucket: .today, isCompletedLane: false)
-        XCTAssertTrue(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: false))
-        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: true))
+        viewModel.toggleColumn(bucket: .today, lane: .open)
+        XCTAssertTrue(viewModel.isColumnCollapsed(bucket: .today, lane: .open))
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, lane: .completed))
 
-        viewModel.toggleColumn(bucket: .today, isCompletedLane: true)
-        XCTAssertTrue(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: true))
+        viewModel.toggleColumn(bucket: .today, lane: .completed)
+        XCTAssertTrue(viewModel.isColumnCollapsed(bucket: .today, lane: .completed))
 
-        viewModel.toggleColumn(bucket: .today, isCompletedLane: false)
-        viewModel.toggleColumn(bucket: .today, isCompletedLane: true)
-        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: false))
-        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, isCompletedLane: true))
+        viewModel.toggleColumn(bucket: .today, lane: .open)
+        viewModel.toggleColumn(bucket: .today, lane: .completed)
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, lane: .open))
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, lane: .completed))
+    }
+
+    func testColumnCollapseScopeIsolationForOverdue() {
+        let viewModel = DailyReviewBoardViewModel()
+
+        viewModel.toggleColumn(bucket: .overdue, lane: .open)
+
+        XCTAssertTrue(viewModel.isColumnCollapsed(bucket: .overdue, lane: .open))
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .today, lane: .open))
+        XCTAssertFalse(viewModel.isColumnCollapsed(bucket: .overdue, lane: .completed))
+    }
+
+    func testBuildBoardKeepsAllTodosInSameBucket() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = Date(timeIntervalSince1970: 1_765_000_000)
+
+        let todos: [Todo] = [
+            Todo(id: "today-a", title: "A", isCompleted: false, isImportant: false, isMyDay: false, dueDate: now, notes: "", listId: nil, launchResourcesRaw: ""),
+            Todo(id: "today-b", title: "B", isCompleted: false, isImportant: false, isMyDay: false, dueDate: now.addingTimeInterval(120), notes: "", listId: nil, launchResourcesRaw: "")
+        ]
+
+        let board = DailyReviewView.buildBoard(todos, now: now, calendar: calendar)
+        let todayOpen = board.openColumns.first(where: { $0.bucket == .today })?.todos.map(\.id) ?? []
+
+        XCTAssertEqual(Set(todayOpen), Set(["today-a", "today-b"]))
+        XCTAssertEqual(todayOpen.count, 2)
     }
 }


### PR DESCRIPTION
## Summary
- Fixed Daily Review bucket rendering so multiple tasks in the same bucket reliably display.
- Tightened column collapse interaction scope so toggle intent is explicit and lane-isolated.

## Root Cause
- The kanban lane used lazy stacks in a nested-scroll layout (`LazyHStack` for columns + `LazyVStack` for cards), which can produce unstable child realization/height behavior in this UI shape.
- Column collapse was toggled by tapping the full header row, which made scope feel too broad and accidental.

## Changes
- `DailyReviewView`
  - Replaced lane columns container from `LazyHStack` to `HStack`.
  - Replaced per-column cards stack from `LazyVStack` to `VStack`.
  - Changed per-column collapse trigger from full-header tap to explicit chevron button.
  - Hardened collapse identity by keying state with `lane + bucket` (`ReviewColumnCollapseKey`).
- `DailyReviewViewTests`
  - Updated collapse tests to lane-aware API.
  - Added `testColumnCollapseScopeIsolationForOverdue`.
  - Added `testBuildBoardKeepsAllTodosInSameBucket`.

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -derivedDataPath "/tmp/todofocus-dd-127-target" -destination "platform=macOS" -only-testing:CoreTests/DailyReviewViewTests`
  - Result: `** TEST SUCCEEDED **`
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -derivedDataPath "/tmp/todofocus-dd-127-fulltest" -destination "platform=macOS"`
  - Result: `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "/tmp/todofocus-dd-127-build" -destination "platform=macOS"`
  - Result: `** BUILD SUCCEEDED **`

## Issue
Closes #127
