### PR TITLE
Fix Daily Review chevron semantics

### DIFF
--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -143,7 +143,7 @@ struct DailyReviewView: View {
                         .background(tokens.bgFloating.opacity(0.8), in: Capsule())
                     Spacer(minLength: 8)
                     if isCompletedLane {
-                        Image(systemName: collapsed ? "chevron.down" : "chevron.up")
+                        Image(systemName: collapsed ? "chevron.right" : "chevron.down")
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(tokens.textSecondary)
                     }
@@ -192,7 +192,7 @@ struct DailyReviewView: View {
                 Button {
                     boardViewModel.toggleColumn(bucket: column.bucket, lane: lane)
                 } label: {
-                    Image(systemName: isColumnCollapsed ? "chevron.down" : "chevron.up")
+                    Image(systemName: isColumnCollapsed ? "chevron.right" : "chevron.down")
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(tokens.textSecondary)
                         .frame(width: 20, height: 20)


### PR DESCRIPTION
## Summary
- align Daily Review chevron behavior with TaskList semantics
- use chevron.down for expanded state
- use chevron.right for collapsed state

## Scope
- macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift

## Notes
- no behavior change to expand/collapse logic, icon semantics only