### PR TITLE
Fix reliability and performance review batch

### DIFF
--- a/docs/superpowers/issues/2026-04-01-reliability-performance-batch-1.md
+++ b/docs/superpowers/issues/2026-04-01-reliability-performance-batch-1.md
@@ -1,0 +1,74 @@
+# Reliability + Performance Batch 1
+
+- Date: 2026-04-01
+- Issue: #131
+- Branch: `fix/reliability-performance-batch-1`
+- Workflow: `systematic-debugging` + `dispatching-parallel-agents`
+
+## Scope
+
+Fix 7 confirmed findings from repository review:
+
+1. QuickCapture hotkey tap idempotency
+2. QuickCapture callback lifetime safety
+3. Export snapshot atomicity
+4. Import launch-resource validation parity
+5. Task list visible/filter recomputation hot path
+6. Detail panel width persistence write frequency
+7. Daily Review due date formatter allocation
+
+## Evidence
+
+### 1) Hotkey tap idempotency
+- `macos/TodoFocusMac/Sources/App/QuickCaptureService.swift`
+- Repeated setup can register duplicate event taps/sources.
+
+### 2) Callback lifetime safety
+- `macos/TodoFocusMac/Sources/App/QuickCaptureService.swift`
+- C callback context currently risks dangling-pointer lifecycle.
+
+### 3) Export snapshot atomicity
+- `macos/TodoFocusMac/Sources/Data/Export/ExportService.swift`
+- Lists and todos are loaded in separate reads, risking cross-table inconsistency.
+
+### 4) Import validation parity
+- `macos/TodoFocusMac/Sources/Data/Export/ExportService.swift`
+- URL resources on import need full validation before persistence.
+
+### 5) Task list recomputation hot path
+- `macos/TodoFocusMac/Sources/App/TodoAppStore.swift`
+- `macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift`
+- Repeated filter/visible recomputation in render path.
+
+### 6) Detail width persistence churn
+- `macos/TodoFocusMac/Sources/RootView.swift`
+- `macos/TodoFocusMac/Sources/App/AppModel.swift`
+- `macos/TodoFocusMac/Sources/App/WindowPersistence.swift`
+- Persisting width on every drag tick causes unnecessary IO.
+
+### 7) Daily Review formatter allocation
+- `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
+- Per-call `DateFormatter` creation in due-date text path.
+
+## Root-Cause Summary
+
+- Lifecycle/concurrency edges around C event tap callback context.
+- Snapshot consistency gap in export path.
+- Validation mismatch between import and runtime parse rules.
+- Repeated computation and persistence in UI hot paths.
+
+## Fix Plan
+
+- Workstream A (Reliability): findings 1-2.
+- Workstream B (Data correctness): findings 3-4.
+- Workstream C (Performance/UI): findings 5-7.
+
+All three are implemented in parallel with disjoint file ownership and integrated on this branch.
+
+## Acceptance Criteria
+
+- No regressions in QuickCapture behavior.
+- Export/import correctness improved with deterministic handling.
+- Reduced repeated work in task filtering and width persistence path.
+- Daily Review date rendering avoids repeated formatter allocation.
+- Build/tests pass on branch before PR.

--- a/macos/TodoFocusMac/Sources/App/AppModel.swift
+++ b/macos/TodoFocusMac/Sources/App/AppModel.swift
@@ -46,9 +46,11 @@ final class AppModel {
         }
     }
 
-    func updateDetailPanelWidth(_ value: Double, windowWidth: Double) {
+    func updateDetailPanelWidth(_ value: Double, windowWidth: Double, persist: Bool = true) {
         let clamped = WindowPersistence.clampDetailWidth(value, windowWidth: windowWidth)
         detailPanelWidth = clamped
-        WindowPersistence.saveDetailWidth(clamped)
+        if persist {
+            WindowPersistence.saveDetailWidth(clamped)
+        }
     }
 }

--- a/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
+++ b/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
@@ -55,6 +55,12 @@ final class QuickCaptureService {
     }
 
     private func setupGlobalHotkey() {
+        if let eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: true)
+            isHotkeyReady = true
+            return
+        }
+
         let eventMask: CGEventMask = (1 << CGEventType.keyDown.rawValue)
 
         let callback: CGEventTapCallBack = { proxy, type, event, refcon in
@@ -79,16 +85,36 @@ final class QuickCaptureService {
             return Unmanaged.passUnretained(event)
         }
 
-        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
-        eventTap = CGEvent.tapCreate(tap: .cgSessionEventTap, place: .headInsertEventTap, options: .defaultTap, eventsOfInterest: eventMask, callback: callback, userInfo: selfPtr)
-
-        guard let eventTap = eventTap else {
+        let retainedSelf = Unmanaged.passRetained(self).toOpaque()
+        guard let eventTap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventMask,
+            callback: callback,
+            userInfo: retainedSelf
+        ) else {
+            Unmanaged<QuickCaptureService>.fromOpaque(retainedSelf).release()
+            isHotkeyReady = false
             return
         }
 
-        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
+        CFMachPortSetInvalidationCallBack(eventTap) { _, refcon in
+            guard let refcon else { return }
+            Unmanaged<QuickCaptureService>.fromOpaque(refcon).release()
+        }
+
+        guard let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0) else {
+            CFMachPortInvalidate(eventTap)
+            isHotkeyReady = false
+            return
+        }
+
+        self.eventTap = eventTap
+        self.runLoopSource = runLoopSource
         CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
         CGEvent.tapEnable(tap: eventTap, enable: true)
+        isHotkeyReady = true
     }
 
     func showCapturePanel() {
@@ -404,8 +430,13 @@ final class QuickCaptureService {
         }
         if let runLoopSource = runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+            CFRunLoopSourceInvalidate(runLoopSource)
+        }
+        if let eventTap = eventTap {
+            CFMachPortInvalidate(eventTap)
         }
         eventTap = nil
         runLoopSource = nil
+        isHotkeyReady = false
     }
 }

--- a/macos/TodoFocusMac/Sources/App/TodoAppStore.swift
+++ b/macos/TodoFocusMac/Sources/App/TodoAppStore.swift
@@ -72,6 +72,19 @@ final class TodoAppStore {
         return todos.filter { visibleIDs.contains($0.id) }
     }
 
+    func filteredVisibleTodos(searchQuery: String) -> [Todo] {
+        let trimmedQuery = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        let visible = visibleTodos
+        guard !trimmedQuery.isEmpty else {
+            return visible
+        }
+
+        return visible.filter {
+            $0.title.localizedCaseInsensitiveContains(trimmedQuery) ||
+            $0.notes.localizedCaseInsensitiveContains(trimmedQuery)
+        }
+    }
+
     var selectedTodo: Todo? {
         guard let id = appModel.selectedTodoID else {
             return nil

--- a/macos/TodoFocusMac/Sources/App/WindowPersistence.swift
+++ b/macos/TodoFocusMac/Sources/App/WindowPersistence.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum WindowPersistence {
     static let detailWidthKey = "todofocus-detail-width"
+    private static let widthSaveEpsilon = 0.5
 
     static func loadDetailWidth(defaultValue: Double = 380) -> Double {
         let value = UserDefaults.standard.double(forKey: detailWidthKey)
@@ -12,7 +13,12 @@ enum WindowPersistence {
     }
 
     static func saveDetailWidth(_ value: Double) {
-        UserDefaults.standard.set(value, forKey: detailWidthKey)
+        let defaults = UserDefaults.standard
+        let existing = defaults.double(forKey: detailWidthKey)
+        if existing > 0, abs(existing - value) < widthSaveEpsilon {
+            return
+        }
+        defaults.set(value, forKey: detailWidthKey)
     }
 
     static func clampDetailWidth(_ value: Double, windowWidth: Double) -> Double {

--- a/macos/TodoFocusMac/Sources/Data/Export/ExportService.swift
+++ b/macos/TodoFocusMac/Sources/Data/Export/ExportService.swift
@@ -63,8 +63,16 @@ final class ExportService {
     }
 
     func exportToJSON() throws -> Data {
-        let lists = try dbQueue.read { db in
-            try ListRecord.fetchAll(db).map { record in
+        let snapshot = try dbQueue.read { db -> (lists: [ExportList], todos: [ExportTodo]) in
+            let listRecords = try ListRecord.fetchAll(db)
+            let todoRecords = try TodoRecord.fetchAll(db)
+            let stepRecords = try StepRecord
+                .order(Column("todoId").asc, Column("sortOrder").asc)
+                .fetchAll(db)
+
+            let stepsByTodoID = Dictionary(grouping: stepRecords, by: \.todoId)
+
+            let lists = listRecords.map { record in
                 ExportList(
                     id: record.id,
                     name: record.name,
@@ -72,22 +80,16 @@ final class ExportService {
                     sortOrder: record.sortOrder
                 )
             }
-        }
 
-        let todos = try dbQueue.read { db in
-            try TodoRecord.fetchAll(db).map { record -> ExportTodo in
-                let steps = try StepRecord
-                    .filter(Column("todoId") == record.id)
-                    .order(Column("sortOrder").asc)
-                    .fetchAll(db)
-                    .map { step in
-                        ExportStep(
-                            id: step.id,
-                            title: step.title,
-                            isCompleted: step.isCompleted,
-                            sortOrder: step.sortOrder
-                        )
-                    }
+            let todos = todoRecords.map { record -> ExportTodo in
+                let steps = (stepsByTodoID[record.id] ?? []).map { step in
+                    ExportStep(
+                        id: step.id,
+                        title: step.title,
+                        isCompleted: step.isCompleted,
+                        sortOrder: step.sortOrder
+                    )
+                }
 
                 let resources = (try? decodeLaunchResources(record.launchResources)) ?? []
                 let portableResources = resources.filter { $0.type == .url }
@@ -109,6 +111,8 @@ final class ExportService {
                     launchResources: portableResources.map { ExportLaunchResource(type: $0.type.rawValue, value: $0.value, label: $0.label) }
                 )
             }
+
+            return (lists: lists, todos: todos)
         }
 
         let exportData = ExportData(
@@ -124,8 +128,8 @@ final class ExportService {
                     "deviceLocalStateExcluded:true"
                 ]
             ),
-            lists: lists,
-            todos: todos
+            lists: snapshot.lists,
+            todos: snapshot.todos
         )
 
         return try exportData.encode()
@@ -297,6 +301,15 @@ final class ExportService {
                         value: er.value,
                         createdAt: Date()
                     )
+                }.compactMap { candidate -> LaunchResource? in
+                    switch validateLaunchResource(candidate) {
+                    case .success(let validated):
+                        return validated
+                    case .failure(let error):
+                        report.skipped.launchResources += 1
+                        report.errors.append("Invalid URL launch resource for todo \(todo.id): \(launchResourceValidationErrorDescription(error))")
+                        return nil
+                    }
                 }
                 let encoded = try JSONEncoder().encode(validResources)
                 try db.execute(
@@ -321,6 +334,23 @@ final class ExportService {
     private func decodeLaunchResources(_ raw: String?) throws -> [LaunchResource] {
         guard let raw, !raw.isEmpty else { return [] }
         return try JSONDecoder().decode([LaunchResource].self, from: Data(raw.utf8))
+    }
+
+    private func launchResourceValidationErrorDescription(_ error: LaunchResourceValidationError) -> String {
+        switch error {
+        case .invalidType:
+            return "invalid type"
+        case .invalidLabel:
+            return "invalid label"
+        case .invalidValue:
+            return "invalid value"
+        case .invalidURL:
+            return "invalid URL"
+        case .invalidFilePath:
+            return "invalid file path"
+        case .invalidAppTarget:
+            return "invalid app target"
+        }
     }
 
     private func createBackupSnapshot() throws -> String {

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -480,6 +480,13 @@ struct DailyReviewView: View {
 }
 
 extension DailyReviewView {
+    private static let dueDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
     enum ReviewLane: String {
         case open
         case completed
@@ -551,10 +558,7 @@ extension DailyReviewView {
         let tomorrow = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
         if let tomorrow, calendar.isDate(dueDate, inSameDayAs: tomorrow) { return "Tomorrow" }
         if dueDate < now { return "Overdue" }
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        return formatter.string(from: dueDate)
+        return dueDateFormatter.string(from: dueDate)
     }
 
     static func dueBucket(for dueDate: Date?, now: Date = Date(), calendar: Calendar = .current) -> ReviewTimeBucket {

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
@@ -18,6 +18,10 @@ struct TaskListView: View {
     }
 
     var body: some View {
+        let filteredTodos = store.filteredVisibleTodos(searchQuery: commandText)
+        let activeTodos = Self.activeTodos(filteredTodos, isOverdueView: isOverdueView)
+        let completedTodos = filteredTodos.filter(\.isCompleted)
+
         VStack(spacing: 12) {
             commandBar
             if let errorMessage = store.mutationErrorMessage {
@@ -59,7 +63,7 @@ struct TaskListView: View {
                     filterPicker
                 }
 
-                Text("\(filteredVisibleTodos.count)")
+                Text("\(filteredTodos.count)")
                     .font(.caption.weight(.semibold))
                     .monospacedDigit()
                     .padding(.horizontal, 10)
@@ -149,7 +153,7 @@ struct TaskListView: View {
                         .frame(maxWidth: .infinity)
 
                     if isCompletedPanelVisible {
-                        completedColumn
+                        completedColumn(todos: completedTodos)
                             .frame(width: 260)
                             .transition(.opacity.combined(with: .move(edge: .trailing)))
                     }
@@ -165,7 +169,7 @@ struct TaskListView: View {
         )
         .padding(16)
         .foregroundStyle(.primary)
-        .animation(MotionTokens.interactiveSpring, value: filteredVisibleTodos.count)
+        .animation(MotionTokens.interactiveSpring, value: filteredTodos.count)
         .animation(MotionTokens.focusEase, value: appModel.timeFilter)
         .alert("Clear completed tasks?", isPresented: $showClearCompletedConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -258,20 +262,12 @@ struct TaskListView: View {
         appModel.selection == .overdue
     }
 
-    private var filteredVisibleTodos: [Todo] {
-        Self.filterTodos(store.visibleTodos, query: commandText)
-    }
-
-    private var activeTodos: [Todo] {
-        var todos = filteredVisibleTodos.filter { !$0.isCompleted }
+    private static func activeTodos(_ todos: [Todo], isOverdueView: Bool) -> [Todo] {
+        var todos = todos.filter { !$0.isCompleted }
         if isOverdueView {
             todos.sort { ($0.dueDate ?? .distantFuture) < ($1.dueDate ?? .distantFuture) }
         }
         return todos
-    }
-
-    private var completedTodos: [Todo] {
-        filteredVisibleTodos.filter(\.isCompleted)
     }
 
     static func filterTodos(_ todos: [Todo], query: String) -> [Todo] {
@@ -333,7 +329,7 @@ struct TaskListView: View {
         .shadow(color: Color.black.opacity(0.12), radius: 6, y: 2)
     }
 
-    private var completedColumn: some View {
+    private func completedColumn(todos: [Todo]) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
                 Button {
@@ -353,7 +349,7 @@ struct TaskListView: View {
                 }
                 .buttonStyle(.plain)
 
-                Text("\(completedTodos.count)")
+                Text("\(todos.count)")
                     .font(.caption2.weight(.medium))
                     .foregroundStyle(tokens.textTertiary)
                     .padding(.horizontal, 6)
@@ -362,7 +358,7 @@ struct TaskListView: View {
 
                 Spacer()
 
-                if !isCompletedCollapsed && !completedTodos.isEmpty {
+                if !isCompletedCollapsed && !todos.isEmpty {
                     Button {
                         showClearCompletedConfirmation = true
                     } label: {
@@ -376,7 +372,7 @@ struct TaskListView: View {
 
             ScrollView {
                 LazyVStack(spacing: 4) {
-                    ForEach(completedTodos) { todo in
+                    ForEach(todos) { todo in
                         TodoRowView(
                             todo: todo,
                             store: store,

--- a/macos/TodoFocusMac/Sources/RootView.swift
+++ b/macos/TodoFocusMac/Sources/RootView.swift
@@ -65,9 +65,12 @@ struct RootView: View {
                                     }
                                     let startWidth = detailPanelDragStartWidth ?? appModel.detailPanelWidth
                                     let next = startWidth - value.translation.width
-                                    appModel.updateDetailPanelWidth(next, windowWidth: proxy.size.width)
+                                    appModel.updateDetailPanelWidth(next, windowWidth: proxy.size.width, persist: false)
                                 }
-                                .onEnded { _ in
+                                .onEnded { value in
+                                    let startWidth = detailPanelDragStartWidth ?? appModel.detailPanelWidth
+                                    let next = startWidth - value.translation.width
+                                    appModel.updateDetailPanelWidth(next, windowWidth: proxy.size.width)
                                     detailPanelDragStartWidth = nil
                                 }
                         )

--- a/macos/TodoFocusMac/Tests/CoreTests/LaunchResourceValidationTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/LaunchResourceValidationTests.swift
@@ -5,6 +5,15 @@ import XCTest
 final class LaunchResourceValidationTests: XCTestCase {
     private let now = Date(timeIntervalSince1970: 1_763_520_000)
 
+    private func makeManager() throws -> DatabaseManager {
+        let path = NSTemporaryDirectory() + UUID().uuidString + ".sqlite"
+        return try DatabaseManager(databasePath: path)
+    }
+
+    private func makeExportService(_ manager: DatabaseManager) -> ExportService {
+        ExportService(dbQueue: manager.dbQueue)
+    }
+
     func testValidateURLAcceptsHTTPSAndTrimsFields() {
         let resource = makeResource(
             id: " ",
@@ -167,6 +176,81 @@ final class LaunchResourceValidationTests: XCTestCase {
 
         let result = trySerializeLaunchResources(items)
         XCTAssertEqual(result, .payloadTooLarge)
+    }
+
+    func testImportRejectsAndReportsInvalidURLLaunchResourcePayload() throws {
+        let manager = try makeManager()
+        let service = makeExportService(manager)
+        let payload = try makeImportPayload(launchResources: [
+            ["type": "url", "value": "https://example.com", "label": "Docs"],
+            ["type": "url", "value": "javascript:alert(1)", "label": "Unsafe"]
+        ])
+
+        let report = try service.executeImportJSON(payload, mode: .replace)
+
+        XCTAssertEqual(report.created.launchResources, 1)
+        XCTAssertEqual(report.skipped.launchResources, 1)
+        XCTAssertTrue(report.errors.contains(where: { $0.contains("Invalid URL launch resource") }))
+
+        let todo = try XCTUnwrap(TodoRepository(dbQueue: manager.dbQueue).fetchTodo(id: "todo-1"))
+        let decoded = try JSONDecoder().decode([LaunchResource].self, from: Data(todo.launchResources.utf8))
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.first?.value, "https://example.com")
+    }
+
+    func testImportKeepsValidURLAndSkipsNonPortableResources() throws {
+        let manager = try makeManager()
+        let service = makeExportService(manager)
+        let payload = try makeImportPayload(launchResources: [
+            ["type": "url", "value": "https://example.com/docs", "label": "Docs"],
+            ["type": "file", "value": "/tmp/spec.md", "label": "Spec"]
+        ])
+
+        let report = try service.executeImportJSON(payload, mode: .replace)
+
+        XCTAssertEqual(report.created.launchResources, 1)
+        XCTAssertEqual(report.skipped.launchResources, 1)
+        XCTAssertTrue(report.errors.isEmpty)
+
+        let todo = try XCTUnwrap(TodoRepository(dbQueue: manager.dbQueue).fetchTodo(id: "todo-1"))
+        let decoded = try JSONDecoder().decode([LaunchResource].self, from: Data(todo.launchResources.utf8))
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.first?.value, "https://example.com/docs")
+    }
+
+    private func makeImportPayload(launchResources: [[String: String]]) throws -> Data {
+        let payload: [String: Any] = [
+            "version": "1.2",
+            "exportedAt": "2026-03-30T12:00:00Z",
+            "lists": [
+                [
+                    "id": "list-1",
+                    "name": "Work",
+                    "color": "#C46849",
+                    "sortOrder": 0
+                ]
+            ],
+            "todos": [
+                [
+                    "id": "todo-1",
+                    "title": "Imported",
+                    "isCompleted": false,
+                    "isImportant": false,
+                    "isMyDay": false,
+                    "dueDate": NSNull(),
+                    "notes": "",
+                    "listId": "list-1",
+                    "focusTimeSeconds": 0,
+                    "recurrence": NSNull(),
+                    "recurrenceInterval": 1,
+                    "sortOrder": 0,
+                    "steps": [],
+                    "launchResources": launchResources
+                ]
+            ]
+        ]
+
+        return try JSONSerialization.data(withJSONObject: payload)
     }
 
     private func makeResource(


### PR DESCRIPTION
## Summary
This PR fixes the 7 confirmed findings tracked in #131, using systematic debugging and parallelized workstreams.

### Reliability
- Make QuickCapture hotkey event-tap setup idempotent.
- Harden event-tap callback context lifetime management.

### Data Correctness
- Make export snapshot atomic in a single database read transaction.
- Validate imported URL launch resources before persistence.
- Report invalid imported URL launch resources in import execution report.

### Performance
- Reduce repeated task filtering recomputation in TaskList hot path.
- Avoid persisting detail-panel width on every drag tick (persist on drag end).
- Cache Daily Review due-date formatter.

## Files
- `macos/TodoFocusMac/Sources/App/QuickCaptureService.swift`
- `macos/TodoFocusMac/Sources/Data/Export/ExportService.swift`
- `macos/TodoFocusMac/Sources/App/TodoAppStore.swift`
- `macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift`
- `macos/TodoFocusMac/Sources/RootView.swift`
- `macos/TodoFocusMac/Sources/App/AppModel.swift`
- `macos/TodoFocusMac/Sources/App/WindowPersistence.swift`
- `macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift`
- `macos/TodoFocusMac/Tests/CoreTests/LaunchResourceValidationTests.swift`
- `docs/superpowers/issues/2026-04-01-reliability-performance-batch-1.md`

## Tests
- Added:
  - `testImportRejectsAndReportsInvalidURLLaunchResourcePayload`
  - `testImportKeepsValidURLAndSkipsNonPortableResources`

## Verification
```bash
xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
# ** TEST SUCCEEDED **

xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"
# ** BUILD SUCCEEDED **
```

Closes #131
