### PR TITLE
Docs: strengthen todofocus workflow with parallel dispatch + review gate

### DIFF
--- a/.codex/skills/todofocus-workflow/SKILL.md
+++ b/.codex/skills/todofocus-workflow/SKILL.md
@@ -12,7 +12,8 @@ Run one consistent path from request to PR: clarify -> plan -> issue -> branch -
 1. Run `brainstorming` before implementation to clarify requirements.
 2. Run `writing-plans` before non-trivial implementation.
 3. Run `systematic-debugging` before any bug fix or unexpected behavior change.
-4. Run verification commands before any completion claim.
+4. Run `requesting-code-review` before merge/PR-ready completion claims.
+5. Run verification commands before any completion claim.
 
 ## Required Sequence
 1. **Clarify (`brainstorming`)**
@@ -35,11 +36,15 @@ Run one consistent path from request to PR: clarify -> plan -> issue -> branch -
    - Keep edits focused and minimal; avoid unrelated refactors.
 7. **Verify (`verification-before-completion`)**
    - Run required test/build gates and capture explicit outcomes.
-8. **PR Artifact**
+8. **Review (`requesting-code-review`)**
+   - Request review on branch diff (`origin/main...HEAD`) after implementation and before PR finalization.
+   - Findings-first output: severity, file:line, concrete risk, required action.
+   - Blocker rule: do not proceed with unfixed Critical/Important findings.
+9. **PR Artifact**
    - Write PR doc:
      - `docs/superpowers/prs/YYYY-MM-DD-<topic>.md`
    - Include: `Closes #<issue>`, change summary, verification commands, verification results.
-9. **Ship (`git-commit` + `gh-cli`)**
+10. **Ship (`git-commit` + `gh-cli`)**
    - Create commit with `git-commit` skill.
    - Push branch and open PR using PR markdown body.
 
@@ -57,6 +62,8 @@ Apply all matching rules.
   - Parallel workers must use model: `gpt-5.3-codex`
 - **About to claim done/passing/fixed**
   - Required: `verification-before-completion`
+- **Before merge / PR-ready handoff**
+  - Required: `requesting-code-review`
 
 ## Subagent Constraints
 - Split ownership by disjoint file sets.


### PR DESCRIPTION
## Summary
Update `todofocus-workflow` skill to include:

1. Parallel-dispatch operating requirements (`dispatching-parallel-agents`)
2. Mandatory `requesting-code-review` gate before PR-ready completion

## What Changed
- Added explicit section: `Parallel Dispatch Requirements (dispatching-parallel-agents)`
  - independent-domain requirement
  - one-agent-per-domain ownership
  - self-contained prompts
  - integration + centralized verification
  - common good patterns and anti-patterns
- Promoted `requesting-code-review` into non-negotiable gates.
- Added required sequence step for review after implementation/verification and before PR finalization.
- Added routing rule: before merge/PR handoff, `requesting-code-review` is required.

## Files
- `.codex/skills/todofocus-workflow/SKILL.md`

## Notes
- Synced the same updated content to local global copies:
  - `~/.codex/skills/todofocus-workflow/SKILL.md`
  - `~/.agents/skills/todofocus-workflow/SKILL.md`

