### PR TITLE
Docs: refresh README coverage for current TodoFocus features

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,34 +41,45 @@ No account required. No cloud dependency required. Data stays on your Mac.
 | Area | What you get |
 |---|---|
 | Quick Capture | Global shortcut `⌘⇧T` to capture from anywhere. |
-| Voice Capture | English (`en-US`) speech recognition with preview + final commit behavior. |
-| Deep Focus | Focus sessions with timer, stats, and menu bar status. |
+| Voice Capture | English (`en-US`) speech recognition, partial preview, final-first commit. |
+| Deep Focus | Focus sessions with timer, menu bar controls, and stats. |
 | Hard Focus | Stronger enforcement mode with app blocking and passphrase-based exit flow. |
-| Launchpad | Attach and launch task resources in one action. |
-| Daily Review | Kanban-style review with Open/Completed lanes and time buckets. |
+| Launchpad | Attach URL/file/app resources, use native pickers, run Launch All. |
+| Daily Review | Kanban review with Open/Completed lanes and time buckets. |
+| Task List UX | Custom list colors, row color indicators, collapsible completed panel. |
+| Detail Panel | Drag-resizable task detail panel with persisted width across launches. |
 | Smart Views | `My Day`, `Important`, `Planned`, `Overdue`, `All Tasks`, and custom lists. |
-| Portability | JSON import/export for lists, todos, steps, and URL launch resources. |
+| Search | `⌘K` local search across task titles and notes. |
+| Portability | JSON import/export for lists, todos, steps, and URL launch resources (file/app are skipped). |
 
 ## Daily Review
 
 Daily Review is built for manual cleanup and planning.
 
-- Open lane buckets: `Overdue`, `Today`, `Tomorrow`, `Later`, `No Date`
-- Completed lane is available and collapsed by default
-- Card actions include `Done`, `My Day`, and `Reschedule`
-- Lightweight by design (no drag-and-drop board mechanics yet)
+- Open and Completed both use: `Overdue`, `Today`, `Tomorrow`, `Later`, `No Date`
+- Completed lane is collapsed by default
+- Each column has independent collapse/expand state
+- Cards are sorted by due date then title
+- Card actions include `Done`, `My Day`, and `Reschedule` (`Today`, `Tomorrow`, `Next 7 Days`, `No Date`)
+
+> [!NOTE]
+> Daily Review uses page-level scrolling with lane/column collapse controls to keep rendering lightweight while still handling large task sets.
 
 ## Quick Capture and Voice
 
 - Open Quick Capture globally with `⌘⇧T`
-- If Deep Focus is active, captured text appends to focus-task notes with timestamp
-- If no Deep Focus is active, captured text creates a new Inbox task
-- Voice mode is currently English-only
+- If Deep Focus is active, capture appends a timestamped line to focus-task notes
+- If no Deep Focus is active, capture creates a new Inbox task from the captured text
+- Voice mode is English-only (`en-US`)
 - Partial transcript is preview-only; final transcript is prioritized for commit
-- Short silence can auto-finalize recording
+- Short silence auto-finalizes recording (~1.6s)
+- If voice permissions are denied, typing still works
 
-> [!NOTE]
-> Quick Capture global shortcut requires Accessibility permission in macOS Privacy settings.
+### Quick Capture permission matrix
+
+- Global hotkey (`⌘⇧T`): Accessibility permission
+- Voice capture: Microphone + Speech Recognition permissions
+- In-app permission warning opens macOS Settings directly
 
 ## Launchpad and Safety
 
@@ -81,7 +92,8 @@ Launchpad lets each task carry execution context:
 Security model:
 
 - Launch operations use native `NSWorkspace`
-- Unsupported payloads are rejected by validation
+- Payload validation rejects invalid or unsupported launch resources
+- URL handling enforces safe payload constraints
 - No shell command execution path is used for launch resources
 
 ## Data and Import/Export
@@ -93,23 +105,38 @@ TodoFocus uses local SQLite storage:
 
 Import/export behavior:
 
-- Format: JSON
+- Format: JSON (`1.0`, `1.1`, `1.2` supported)
 - Portable entities: lists, todos, steps, URL launch resources
-- File/app launch resources are intentionally skipped for cross-device portability
-- Import supports `merge` and `replace` modes
+- Non-portable `file`/`app` launch resources are skipped and reported
+- Import `merge`: upserts matching IDs and keeps unrelated local data
+- Import `replace`: clears app data then imports, with automatic backup snapshot
+- Replace backups are written to `~/Library/Application Support/todofocus/backups/`
+- Preflight validation checks version compatibility and duplicate IDs
 
 > [!TIP]
 > File and app paths are machine-local. URL-only portability avoids broken resources when moving to another Mac.
 
 ## Keyboard Shortcuts
 
+### Global
+
 | Shortcut | Action |
 |---|---|
-| `⌘⇧T` | Global Quick Capture |
-| `⌘⇧F` | Start Deep Focus on selected task |
-| `⌘K` | Search tasks |
+| `⌘⇧T` | Open Quick Capture |
+
+### In-app
+
+| Shortcut | Action |
+|---|---|
+| `⌘⇧F` | Start Deep Focus for selected task |
+| `⌘K` | Search tasks (title + notes) |
 | `⌘⇧N` | Add task to current view |
 | `⌘⇧L` | Toggle theme |
+| `Return` | Confirm Quick Capture Add |
+| `Esc` | Cancel Quick Capture |
+
+> [!NOTE]
+> The in-app shortcut hint bar mirrors the current bindings: `⌘⇧T`, `⌘⇧F`, `⌘K`, `⌘⇧L`, `⌘⇧N`.
 
 ## Build From Source
 
@@ -117,19 +144,48 @@ Import/export behavior:
 
 - macOS 14+
 - Xcode 16+
-- `xcodegen`
+- `xcodegen` 2.38.0+
+- Git submodules initialized (GRDB is vendored as a submodule)
 
 ### Build and test
 
 ```bash
 brew install xcodegen
-git clone https://github.com/michaelmjhhhh/TodoFocus.git
+git clone --recurse-submodules https://github.com/michaelmjhhhh/TodoFocus.git
 cd TodoFocus/macos/TodoFocusMac
 
 xcodegen generate
 xcodebuild test -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
 xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "build/DerivedData" -destination "platform=macOS"
 ```
+
+If you cloned without submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+## Native Release Flow (CI-first)
+
+Release assets are produced by GitHub Actions workflow `release-macos-native`.
+
+1. Start from updated `main`
+2. Create and push tag `vX.Y.Z`
+3. Wait for `release-macos-native` to finish
+4. Verify release assets (`TodoFocus-macos-universal.zip` + `.sha256`)
+
+```bash
+git checkout main && git pull
+git tag vX.Y.Z
+git push origin vX.Y.Z
+
+gh run list --workflow release-macos-native --limit 5
+gh run watch <run-id>
+gh release view vX.Y.Z --json assets,url
+```
+
+> [!IMPORTANT]
+> `release-macos-native` is the native release path. The legacy `release-macos` workflow is not the primary flow for current native packaging.
 
 ## Quick Start
 
@@ -138,6 +194,7 @@ xcodebuild build -project "TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -confi
 3. Open once and grant requested permissions.
 4. Create one task, add one URL resource, then run one Deep Focus session.
 5. Trigger `⌘⇧T` and verify Quick Capture flow.
+6. Open Daily Review and run one manual cleanup pass.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

This docs-only PR updates `README.md` so it reflects the current shipped behavior and delivery workflow.

## What changed

- Expanded feature coverage:
  - Daily Review behavior (lanes, buckets, collapse semantics, actions)
  - Task List UX details (custom list colors, row indicators, completed panel collapse)
  - Detail panel resize + persisted width
  - Launchpad native picker flow and safety model
  - Search scope (`title + notes`)
- Clarified Quick Capture / Voice:
  - English-only voice mode (`en-US`)
  - partial preview + final-priority behavior
  - short-silence auto-finalize
  - permission matrix (Accessibility / Mic / Speech)
- Updated import/export docs:
  - URL-only portable launch resources
  - `merge` vs `replace`
  - replace backup snapshot path
  - preflight validation behavior
- Improved developer-facing guidance:
  - `xcodegen` minimum version
  - submodule initialization requirement (GRDB)
  - CI-first native release flow (`release-macos-native`)
  - note about legacy `release-macos` workflow
- Reorganized keyboard shortcuts into Global and In-app groups.

## Scope

- Docs only (`README.md`)
- No runtime code changes

