### PR TITLE
Fix export legacy v1 decode and backup filename collision risk

### DIFF
--- a/docs/superpowers/issues/2026-04-01-export-legacy-v1-backup-uniqueness.md
+++ b/docs/superpowers/issues/2026-04-01-export-legacy-v1-backup-uniqueness.md
@@ -1,0 +1,21 @@
+# Fix export legacy v1 decode and backup snapshot uniqueness
+
+## Summary
+Two reliability gaps remain in import/export:
+
+1. Legacy `v1.0` payloads with non-empty todos can fail decode because newer required fields (`recurrenceInterval`, `sortOrder`) are not guaranteed in historical files.
+2. Replace-import backups are named with second-level timestamp only, so rapid consecutive imports can collide and overwrite backup files.
+
+## Scope
+- Add backward-compatible decode defaults for `ExportTodo` missing legacy fields.
+- Make backup snapshot filenames collision-resistant.
+- Add regression tests for both behaviors.
+
+## Acceptance Criteria
+- A `v1.0` payload with one todo and missing modern fields decodes successfully.
+- Replace import produces a backup filename with high-entropy uniqueness marker.
+- Full macOS test suite passes.
+
+## Out of Scope
+- Changing export schema version beyond current `1.3`.
+- Reworking import modes or merge semantics beyond this bugfix.

--- a/docs/superpowers/plans/2026-04-01-export-legacy-v1-backup-uniqueness.md
+++ b/docs/superpowers/plans/2026-04-01-export-legacy-v1-backup-uniqueness.md
@@ -1,0 +1,26 @@
+# Plan: Export Legacy v1 Compatibility + Backup Filename Uniqueness
+
+## Context
+This is a bugfix iteration for import/export reliability after PR #139.
+
+## Root Cause
+1. `ExportTodo` relies on synthesized decoding with non-optional fields added after v1.0.
+2. `createBackupSnapshot()` uses `yyyyMMdd-HHmmss` only.
+
+## Implementation Steps
+1. Add regression tests in `ExportServiceTests`:
+   - decode legacy `v1.0` todo with missing modern fields
+   - backup filename structure includes millisecond + random suffix
+2. Implement custom decoding defaults in `ExportTodo`.
+3. Update backup filename generation to include sub-second precision and UUID suffix.
+4. Run verification:
+   - `xcodebuild test ...`
+   - `xcodebuild build ... Release ...`
+5. Open PR with issue linkage and verification evidence.
+
+## Risks
+- Changing decode behavior could unintentionally mask malformed data.
+
+## Mitigation
+- Keep defaults narrow and explicit to known legacy fields only.
+- Preserve strict validation elsewhere.

--- a/docs/superpowers/prs/2026-04-01-fix-140-export-legacy-v1-backup-uniqueness.md
+++ b/docs/superpowers/prs/2026-04-01-fix-140-export-legacy-v1-backup-uniqueness.md
@@ -1,0 +1,23 @@
+## Summary
+- fix import compatibility for historical `v1.0` exports with non-empty todos by adding decode defaults for fields introduced later (`recurrenceInterval`, `sortOrder`, `steps`, `launchResources`)
+- harden replace-import backup naming to avoid collisions by adding millisecond timestamp + random suffix
+- add regression tests for both cases
+
+## Root Cause
+- `ExportTodo` used synthesized decoding with non-optional fields that can be absent in legacy `v1.0` payloads.
+- backup filenames used second-level precision only.
+
+## Changes
+- `ExportTodo` custom `Decodable` defaults in `ExportModels.swift`
+- backup filename generation updated in `ExportService.createBackupSnapshot()`
+- tests added in `ExportServiceTests`:
+  - `testDecodeV1_0PayloadWithLegacyTodoDefaultsMissingFields`
+  - `testReplaceImportBackupFilenameContainsMillisAndEntropySuffix`
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`
+
+Closes #140

--- a/macos/TodoFocusMac/Sources/Data/Export/ExportModels.swift
+++ b/macos/TodoFocusMac/Sources/Data/Export/ExportModels.swift
@@ -53,6 +53,49 @@ struct ExportTodo: Codable {
     let launchResources: [ExportLaunchResource]
 }
 
+extension ExportTodo {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case isCompleted
+        case isImportant
+        case isMyDay
+        case dueDate
+        case notes
+        case listId
+        case focusTimeSeconds
+        case recurrence
+        case recurrenceInterval
+        case sortOrder
+        case createdAt
+        case updatedAt
+        case lastCompletedAt
+        case steps
+        case launchResources
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        isCompleted = try container.decode(Bool.self, forKey: .isCompleted)
+        isImportant = try container.decode(Bool.self, forKey: .isImportant)
+        isMyDay = try container.decode(Bool.self, forKey: .isMyDay)
+        dueDate = try container.decodeIfPresent(Date.self, forKey: .dueDate)
+        notes = try container.decodeIfPresent(String.self, forKey: .notes) ?? ""
+        listId = try container.decodeIfPresent(String.self, forKey: .listId)
+        focusTimeSeconds = try container.decodeIfPresent(Int.self, forKey: .focusTimeSeconds)
+        recurrence = try container.decodeIfPresent(String.self, forKey: .recurrence)
+        recurrenceInterval = max(1, try container.decodeIfPresent(Int.self, forKey: .recurrenceInterval) ?? 1)
+        sortOrder = try container.decodeIfPresent(Int.self, forKey: .sortOrder) ?? 0
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
+        lastCompletedAt = try container.decodeIfPresent(Date.self, forKey: .lastCompletedAt)
+        steps = try container.decodeIfPresent([ExportStep].self, forKey: .steps) ?? []
+        launchResources = try container.decodeIfPresent([ExportLaunchResource].self, forKey: .launchResources) ?? []
+    }
+}
+
 struct ExportStep: Codable {
     let id: String
     let title: String

--- a/macos/TodoFocusMac/Sources/Data/Export/ExportService.swift
+++ b/macos/TodoFocusMac/Sources/Data/Export/ExportService.swift
@@ -418,8 +418,9 @@ final class ExportService {
         try fm.createDirectory(at: base, withIntermediateDirectories: true)
 
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMdd-HHmmss"
-        let filename = "todofocus-backup-\(formatter.string(from: Date())).json"
+        formatter.dateFormat = "yyyyMMdd-HHmmss-SSS"
+        let suffix = UUID().uuidString.prefix(8).lowercased()
+        let filename = "todofocus-backup-\(formatter.string(from: Date()))-\(suffix).json"
         let path = base.appendingPathComponent(filename)
         do {
             try backupData.write(to: path, options: .atomic)

--- a/macos/TodoFocusMac/Tests/DataTests/ExportServiceTests.swift
+++ b/macos/TodoFocusMac/Tests/DataTests/ExportServiceTests.swift
@@ -95,6 +95,38 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertEqual(decoded.version, "1.0")
     }
 
+    func testDecodeV1_0PayloadWithLegacyTodoDefaultsMissingFields() throws {
+        let payload = """
+        {
+          "version": "1.0",
+          "exportedAt": "2026-03-28T12:00:00Z",
+          "lists": [],
+          "todos": [
+            {
+              "id": "todo-legacy",
+              "title": "Legacy Todo",
+              "isCompleted": false,
+              "isImportant": true,
+              "isMyDay": false,
+              "dueDate": null,
+              "notes": "legacy note",
+              "listId": null,
+              "focusTimeSeconds": 15
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try ExportData.decode(from: payload)
+        let todo = try XCTUnwrap(decoded.todos.first)
+
+        XCTAssertEqual(todo.id, "todo-legacy")
+        XCTAssertEqual(todo.recurrenceInterval, 1)
+        XCTAssertEqual(todo.sortOrder, 0)
+        XCTAssertEqual(todo.steps.count, 0)
+        XCTAssertEqual(todo.launchResources.count, 0)
+    }
+
     func testPreflightRejectsUnsupportedVersion() throws {
         let manager = try makeManager()
         let service = makeService(manager)
@@ -232,6 +264,22 @@ final class ExportServiceTests: XCTestCase {
 
         XCTAssertNotNil(report.backupFilePath)
         XCTAssertTrue(FileManager.default.fileExists(atPath: report.backupFilePath ?? ""))
+    }
+
+    func testReplaceImportBackupFilenameContainsMillisAndEntropySuffix() throws {
+        let manager = try makeManager()
+        try seedBasicData(manager)
+        let service = makeService(manager)
+
+        let data = try service.exportToJSON()
+        let report = try service.executeImportJSON(data, mode: .replace)
+        let backupPath = try XCTUnwrap(report.backupFilePath)
+        let filename = URL(fileURLWithPath: backupPath).lastPathComponent
+
+        let pattern = #"^todofocus-backup-\d{8}-\d{6}-\d{3}-[a-f0-9]{8}\.json$"#
+        let regex = try NSRegularExpression(pattern: pattern)
+        let range = NSRange(location: 0, length: filename.utf16.count)
+        XCTAssertNotNil(regex.firstMatch(in: filename, range: range))
     }
 
     func testMergeImportKeepsUnrelatedLocalRows() throws {


### PR DESCRIPTION
## Summary
- fix import compatibility for historical `v1.0` exports with non-empty todos by adding decode defaults for fields introduced later (`recurrenceInterval`, `sortOrder`, `steps`, `launchResources`)
- harden replace-import backup naming to avoid collisions by adding millisecond timestamp + random suffix
- add regression tests for both cases

## Root Cause
- `ExportTodo` used synthesized decoding with non-optional fields that can be absent in legacy `v1.0` payloads.
- backup filenames used second-level precision only.

## Changes
- `ExportTodo` custom `Decodable` defaults in `ExportModels.swift`
- backup filename generation updated in `ExportService.createBackupSnapshot()`
- tests added in `ExportServiceTests`:
  - `testDecodeV1_0PayloadWithLegacyTodoDefaultsMissingFields`
  - `testReplaceImportBackupFilenameContainsMillisAndEntropySuffix`

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`

Closes #140
