### PR TITLE
Fix false Hard Focus error banner after timed Deep Focus completion

### DIFF
--- a/docs/superpowers/issues/2026-04-01-hard-focus-timer-end-banner-regression.md
+++ b/docs/superpowers/issues/2026-04-01-hard-focus-timer-end-banner-regression.md
@@ -1,0 +1,23 @@
+# Fix: Deep Focus timed completion shows false Hard Focus error banner
+
+## Symptom
+After a timed Deep Focus session ends naturally, UI shows:
+`Failed to end Hard Focus session ... (HardFocusError error 2)`
+
+## Reproduction
+1. Start Deep Focus in timed mode.
+2. Wait for timer completion.
+3. Observe transient error banner despite normal completion.
+
+## Root Cause
+Timed completion path can attempt Hard Focus teardown more than once (race/ordering between timers and teardown paths).
+Second teardown throws `HardFocusError.noActiveSession`, which is currently surfaced as mutation error.
+
+## Fix
+Treat `HardFocusError.noActiveSession` as idempotent success for teardown/finalization paths.
+Keep surfacing real teardown failures.
+
+## Acceptance
+- No error banner on normal timed completion.
+- Non-benign teardown failures still surface.
+- Tests pass.

--- a/docs/superpowers/plans/2026-04-01-hard-focus-timer-end-banner-regression.md
+++ b/docs/superpowers/plans/2026-04-01-hard-focus-timer-end-banner-regression.md
@@ -1,0 +1,15 @@
+# Plan: Hard Focus timed-end false error banner regression (Issue #147)
+
+## Systematic Debugging
+- Evidence gathered from `TodoAppStore.startDeepFocus` timer callback and `HardFocusSessionManager.emergencyEndSession` behavior.
+- `HardFocusError.noActiveSession` is benign in idempotent teardown contexts.
+
+## Implementation
+1. Add centralized suppression rule for benign teardown error (`noActiveSession`).
+2. Apply suppression in timed-completion and auto-termination teardown catch blocks.
+3. Add regression tests for suppression rule.
+4. Verify full test/build pipeline.
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`

--- a/docs/superpowers/prs/2026-04-01-fix-147-hard-focus-timer-end-banner.md
+++ b/docs/superpowers/prs/2026-04-01-fix-147-hard-focus-timer-end-banner.md
@@ -1,0 +1,25 @@
+## Summary
+- fix false mutation-error banner shown after timed Deep Focus completion
+- treat `HardFocusError.noActiveSession` as benign in Hard Focus teardown paths
+- keep real Hard Focus teardown failures visible
+
+## Root Cause
+Timed completion could race into duplicate Hard Focus teardown attempts.
+Second teardown threw `noActiveSession`, which was incorrectly surfaced as a user-facing error.
+
+## Changes
+- add centralized suppression rule:
+  - `TodoAppStore.shouldSuppressHardFocusTeardownError(_:)`
+- apply suppression in three teardown catch paths:
+  - timer-completion callback teardown
+  - `endDeepFocus` teardown
+  - `endFocusForAppTermination` teardown
+- add tests for suppression behavior in `TodoAppStoreTests`
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`
+
+Closes #147

--- a/macos/TodoFocusMac/Sources/App/TodoAppStore.swift
+++ b/macos/TodoFocusMac/Sources/App/TodoAppStore.swift
@@ -130,6 +130,13 @@ final class TodoAppStore {
         mutationErrorMessage = "\(context): \(error.localizedDescription)"
     }
 
+    static func shouldSuppressHardFocusTeardownError(_ error: Error) -> Bool {
+        guard let hardFocusError = error as? HardFocusError else {
+            return false
+        }
+        return hardFocusError == .noActiveSession
+    }
+
     @discardableResult
     func quickAdd(
         title: String,
@@ -383,9 +390,13 @@ final class TodoAppStore {
                     }
                     Task { @MainActor [weak self] in
                         do {
-                            try await self?.hardFocusManager.emergencyEndSession()
+                            if self?.hardFocusManager.isEnforcing == true {
+                                try await self?.hardFocusManager.emergencyEndSession()
+                            }
                         } catch {
-                            self?.setMutationError(error, context: "Failed to end Hard Focus session")
+                            if !Self.shouldSuppressHardFocusTeardownError(error) {
+                                self?.setMutationError(error, context: "Failed to end Hard Focus session")
+                            }
                         }
                     }
                 }
@@ -422,7 +433,9 @@ final class TodoAppStore {
             do {
                 try await hardFocusManager.emergencyEndSession()
             } catch {
-                setMutationError(error, context: "Failed to end Hard Focus session")
+                if !Self.shouldSuppressHardFocusTeardownError(error) {
+                    setMutationError(error, context: "Failed to end Hard Focus session")
+                }
             }
         }
 
@@ -459,7 +472,9 @@ final class TodoAppStore {
             do {
                 try await hardFocusManager.emergencyEndSession()
             } catch {
-                setMutationError(error, context: "Failed to end Hard Focus session")
+                if !Self.shouldSuppressHardFocusTeardownError(error) {
+                    setMutationError(error, context: "Failed to end Hard Focus session")
+                }
             }
         }
     }

--- a/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift
@@ -411,6 +411,15 @@ final class TodoAppStoreTests: XCTestCase {
         XCTAssertEqual(TaskListView.filterTodos(preFiltered, query: "").map(\.id), ["a", "b"])
         XCTAssertEqual(TaskListView.filterTodos(preFiltered, query: "vendor").map(\.id), [])
     }
+
+    func testShouldSuppressHardFocusTeardownErrorReturnsTrueForNoActiveSession() {
+        XCTAssertTrue(TodoAppStore.shouldSuppressHardFocusTeardownError(HardFocusError.noActiveSession))
+    }
+
+    func testShouldSuppressHardFocusTeardownErrorReturnsFalseForNonBenignErrors() {
+        XCTAssertFalse(TodoAppStore.shouldSuppressHardFocusTeardownError(HardFocusError.invalidPassphrase))
+        XCTAssertFalse(TodoAppStore.shouldSuppressHardFocusTeardownError(NSError(domain: "x", code: 1)))
+    }
 }
 
 private final class MockTestHardFocusAgentManager: HardFocusAgentControlling {


### PR DESCRIPTION
## Summary
- fix false mutation-error banner shown after timed Deep Focus completion
- treat `HardFocusError.noActiveSession` as benign in Hard Focus teardown paths
- keep real Hard Focus teardown failures visible

## Root Cause
Timed completion could race into duplicate Hard Focus teardown attempts.
Second teardown threw `noActiveSession`, which was incorrectly surfaced as a user-facing error.

## Changes
- add centralized suppression rule:
  - `TodoAppStore.shouldSuppressHardFocusTeardownError(_:)`
- apply suppression in three teardown catch paths:
  - timer-completion callback teardown
  - `endDeepFocus` teardown
  - `endFocusForAppTermination` teardown
- add tests for suppression behavior in `TodoAppStoreTests`

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`

Closes #147
