### PR TITLE
🎨 Palette: Enhance accessibility and tooltips for icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Consistent Icon-Only Button Accessibility]
+**Learning:** Icon-only buttons in the existing codebase often lacked either `.accessibilityLabel` (for screen readers) or `.help` (for tooltips), leading to inconsistent UX for different input methods.
+**Action:** When adding or modifying icon-only buttons, always include both `.accessibilityLabel` and `.help` to ensure full accessibility and discoverability. For toggle states, ensure the labels and tooltips are dynamic and reflect the current state (e.g., "Mark as completed" vs "Mark as not completed").

--- a/macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCaptureView.swift
+++ b/macos/TodoFocusMac/Sources/Features/QuickCapture/QuickCaptureView.swift
@@ -57,6 +57,7 @@ struct QuickCaptureView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(service.isRecordingVoice ? "Stop recording" : "Start recording")
+                .help(service.isRecordingVoice ? "Stop recording" : "Start recording")
 
                 if showSuccess {
                     Image(systemName: "checkmark.circle.fill")

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
@@ -237,6 +237,7 @@ struct SidebarView: View {
                 .background(tokens.bgFloating, in: RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(themeTooltip)
         .help(themeTooltip)
     }
 }

--- a/macos/TodoFocusMac/Sources/Features/TaskDetail/LaunchResourceEditorView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskDetail/LaunchResourceEditorView.swift
@@ -68,6 +68,8 @@ struct LaunchResourceEditorView: View {
                     .background(tokens.accentTerracotta, in: Capsule())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Launch all resources")
+                .help("Launch all resources")
             }
 
             Button {
@@ -86,6 +88,8 @@ struct LaunchResourceEditorView: View {
                     }
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Add resource")
+            .help("Add resource")
             .disabled(draft.count >= 12)
             .opacity(draft.count >= 12 ? 0.5 : 1)
         }
@@ -273,6 +277,8 @@ struct LaunchResourceEditorView: View {
                     .background(tokens.bgFloating, in: Circle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Launch resource")
+            .help("Launch resource")
 
             Button {
                 withAnimation {
@@ -286,6 +292,8 @@ struct LaunchResourceEditorView: View {
                     .frame(width: 24, height: 24)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Remove resource")
+            .help("Remove resource")
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)

--- a/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
@@ -218,6 +218,8 @@ struct TaskDetailView: View {
                     }
                     .buttonStyle(.plain)
                     .foregroundStyle(tokens.mutedText)
+                    .accessibilityLabel("Close detail")
+                    .help("Close detail")
                 }
                 .padding(.horizontal, 6)
                 .padding(.vertical, 4)
@@ -614,6 +616,8 @@ struct StepsEditorView: View {
                     }
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Delete step")
+            .help("Delete step")
         }
         .padding(.vertical, 8)
         .padding(.horizontal, 10)

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
@@ -104,6 +104,7 @@ struct TaskListView: View {
                     }
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(isCompletedPanelVisible ? "Hide completed panel" : "Show completed panel")
                 .help(isCompletedPanelVisible ? "Hide completed panel" : "Show completed panel")
             }
 

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TodoRowView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TodoRowView.swift
@@ -61,6 +61,7 @@ struct TodoRowView: View {
                     .padding(2)
             }
             .accessibilityLabel(todo.isCompleted ? "Mark as not completed" : "Mark as completed")
+            .help(todo.isCompleted ? "Mark as not completed" : "Mark as completed")
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(todo.title)
@@ -89,12 +90,16 @@ struct TodoRowView: View {
                 }
                 .buttonStyle(AppIconButtonStyle())
                 .foregroundStyle(todo.isImportant ? Color.yellow : tokens.mutedText)
+                .accessibilityLabel(todo.isImportant ? "Mark as not important" : "Mark as important")
+                .help(todo.isImportant ? "Mark as not important" : "Mark as important")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                 }
                 .buttonStyle(AppIconButtonStyle())
                 .foregroundStyle(tokens.mutedText)
+                .accessibilityLabel("Delete task")
+                .help("Delete task")
             }
             .frame(width: 62, alignment: .trailing)
             .opacity(isSecondaryControlsVisible ? 1 : 0.001)


### PR DESCRIPTION
This PR enhances the accessibility and usability of TodoFocus by adding descriptive labels and tooltips to icon-only buttons across all major views. This ensures that screen reader users can understand the purpose of each button and that all users can benefit from informative hover states (tooltips).

💡 What:
- Added `.accessibilityLabel` and `.help` (tooltip) to several icon-only buttons including "Star", "Trash", "Close", "Add", "Launch", and "Theme Toggle".
- Implemented dynamic labels/tooltips for toggle states like "Mark as completed/not completed".

🎯 Why:
- Icon-only buttons can be ambiguous without text. Accessibility labels and tooltips solve this for screen reader and mouse users respectively.

♿ Accessibility:
- Significantly improved screen reader support for key task management and navigation actions.
- Added tooltips to explain the function of several "rocket" and "mic" icons that might not be immediately obvious.

---
*PR created automatically by Jules for task [12439141923764806616](https://jules.google.com/task/12439141923764806616) started by @michaelmjhhhh*