### PR TITLE
Fix Quick Add highlighting stability and simplify natural-language tokens

### DIFF
--- a/docs/superpowers/issues/2026-04-03-quick-add-natural-language-token-highlighting.md
+++ b/docs/superpowers/issues/2026-04-03-quick-add-natural-language-token-highlighting.md
@@ -1,0 +1,9 @@
+# Quick Add: Natural Language Token Highlighting
+
+## Goal
+In Quick Add, render recognized natural-language tokens with accent highlighting while users type.
+
+## Acceptance
+- `tomorrow buy milk` highlights `tomorrow`.
+- Supported tokens highlight consistently with parser behavior.
+- Submission behavior and keyboard interactions stay unchanged.

--- a/docs/superpowers/plans/2026-04-03-quick-add-natural-language-token-highlighting.md
+++ b/docs/superpowers/plans/2026-04-03-quick-add-natural-language-token-highlighting.md
@@ -1,0 +1,21 @@
+# Plan: Quick Add Natural Language Token Highlighting
+
+## Goal
+Highlight recognized natural-language tokens inline in Quick Add input (e.g. `tomorrow buy milk` should render `tomorrow` highlighted) while keeping existing parsing behavior unchanged.
+
+## Scope
+- Task List `QuickAddView` only.
+- Highlight tokens currently supported by parser:
+  - Date: `today`, `tomorrow`, `next week`, weekdays (`mon..sun`, full names)
+  - Time: `9am`, `9:30am`, `21:15`
+  - Flags: `!`, `!high`, `@myday`
+  - List token: `#listName`
+
+## Design
+1. Extend `QuickAddNaturalLanguageParser` with reusable token analysis that returns recognized token ranges in source string.
+2. Reuse the same recognition logic for parse + highlight to prevent drift.
+3. Update `QuickAddView` rendering to show highlighted text while preserving typing interactions and submit behavior.
+4. Add parser tests for token highlight ranges.
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`

--- a/docs/superpowers/prs/2026-04-03-quick-add-highlighting-and-nl-token-rules.md
+++ b/docs/superpowers/prs/2026-04-03-quick-add-highlighting-and-nl-token-rules.md
@@ -1,0 +1,25 @@
+# PR: Quick Add Highlighting Stability + NL Token Rule Simplification
+
+## Summary
+- replace Quick Add overlay highlighting with AppKit-backed attributed input to keep caret/focus behavior stable
+- fix focus-loss regression when typing in Quick Add input
+- simplify natural-language token rules per product direction:
+  - remove time parsing/highlighting (`9am`, `9:30am`, `21:15`)
+  - remove `!high` token (keep `!` only)
+  - remove `#list` parsing/highlighting
+- update parser/store tests for new expected behavior and precedence coverage
+
+## Files
+- `macos/TodoFocusMac/Sources/Features/TaskList/QuickAddHighlightingTextField.swift` (new)
+- `macos/TodoFocusMac/Sources/Features/TaskList/QuickAddView.swift`
+- `macos/TodoFocusMac/Sources/Core/Parsing/QuickAddNaturalLanguageParser.swift`
+- `macos/TodoFocusMac/Sources/App/TodoAppStore.swift`
+- `macos/TodoFocusMac/Tests/CoreTests/QuickAddNaturalLanguageParserTests.swift`
+- `macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift`
+- docs artifacts under `docs/superpowers/{issues,plans}`
+
+## Verification
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`

--- a/macos/TodoFocusMac/Sources/App/TodoAppStore.swift
+++ b/macos/TodoFocusMac/Sources/App/TodoAppStore.swift
@@ -171,7 +171,7 @@ final class TodoAppStore {
         let parsed = QuickAddNaturalLanguageParser.parse(input, now: now(), calendar: calendar)
         let resolvedImportant = parsed.isImportant || defaultIsImportant
         let resolvedMyDay = parsed.isMyDay || defaultIsMyDay
-        let resolvedList = resolveList(for: parsed.listName) ?? defaultList
+        let resolvedList = defaultList
         let planned = defaultPlanned || parsed.dueDate != nil
 
         let created = try quickAdd(

--- a/macos/TodoFocusMac/Sources/Core/Parsing/QuickAddNaturalLanguageParser.swift
+++ b/macos/TodoFocusMac/Sources/Core/Parsing/QuickAddNaturalLanguageParser.swift
@@ -4,29 +4,59 @@ struct QuickAddParsedInput: Equatable {
     let title: String
     let isImportant: Bool
     let isMyDay: Bool
-    let listName: String?
     let dueDate: Date?
 }
 
 enum QuickAddNaturalLanguageParser {
     static func parse(_ input: String, now: Date, calendar: Calendar = .current) -> QuickAddParsedInput {
-        let tokens = input
-            .split(whereSeparator: \.isWhitespace)
-            .map(String.init)
+        let analysis = analyze(input, now: now, calendar: calendar)
 
+        let title = analysis.tokens
+            .enumerated()
+            .compactMap { analysis.consumed.contains($0.offset) ? nil : $0.element.raw }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let dueDate = resolveDueDate(
+            day: analysis.parsedDay,
+            now: now,
+            calendar: calendar
+        )
+
+        return QuickAddParsedInput(
+            title: title,
+            isImportant: analysis.isImportant,
+            isMyDay: analysis.isMyDay,
+            dueDate: dueDate
+        )
+    }
+
+    static func highlightedTokenRanges(in input: String, now: Date, calendar: Calendar = .current) -> [Range<String.Index>] {
+        let analysis = analyze(input, now: now, calendar: calendar)
+        return analysis.tokens
+            .enumerated()
+            .compactMap { analysis.consumed.contains($0.offset) ? $0.element.range : nil }
+    }
+
+    private static func normalizeToken(_ token: String) -> String {
+        token
+            .trimmingCharacters(in: .punctuationCharacters.subtracting(CharacterSet(charactersIn: "#@!")))
+            .lowercased()
+    }
+
+    private static func analyze(_ input: String, now: Date, calendar: Calendar) -> TokenAnalysis {
+        let tokens = tokenize(input)
         var consumed = Set<Int>()
         var isImportant = false
         var isMyDay = false
-        var listName: String?
         var parsedDay: Date?
-        var parsedTime: (hour: Int, minute: Int)?
 
         var idx = 0
         while idx < tokens.count {
-            let token = tokens[idx]
+            let token = tokens[idx].raw
             let normalized = normalizeToken(token)
 
-            if normalized == "!" || normalized == "!high" {
+            if normalized == "!" {
                 isImportant = true
                 consumed.insert(idx)
                 idx += 1
@@ -35,14 +65,6 @@ enum QuickAddNaturalLanguageParser {
 
             if normalized == "@myday" {
                 isMyDay = true
-                consumed.insert(idx)
-                idx += 1
-                continue
-            }
-
-            if token.hasPrefix("#"), token.count > 1 {
-                listName = String(token.dropFirst())
-                    .trimmingCharacters(in: .punctuationCharacters)
                 consumed.insert(idx)
                 idx += 1
                 continue
@@ -62,7 +84,7 @@ enum QuickAddNaturalLanguageParser {
                 continue
             }
 
-            if normalized == "next", idx + 1 < tokens.count, normalizeToken(tokens[idx + 1]) == "week" {
+            if normalized == "next", idx + 1 < tokens.count, normalizeToken(tokens[idx + 1].raw) == "week" {
                 parsedDay = calendar.date(byAdding: .day, value: 7, to: calendar.startOfDay(for: now))
                 consumed.insert(idx)
                 consumed.insert(idx + 1)
@@ -77,42 +99,35 @@ enum QuickAddNaturalLanguageParser {
                 continue
             }
 
-            if let time = parseTime(normalized) {
-                parsedTime = time
-                consumed.insert(idx)
-                idx += 1
-                continue
-            }
-
             idx += 1
         }
 
-        let title = tokens
-            .enumerated()
-            .compactMap { consumed.contains($0.offset) ? nil : $0.element }
-            .joined(separator: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        let dueDate = resolveDueDate(
-            day: parsedDay,
-            time: parsedTime,
-            now: now,
-            calendar: calendar
-        )
-
-        return QuickAddParsedInput(
-            title: title,
+        return TokenAnalysis(
+            tokens: tokens,
+            consumed: consumed,
             isImportant: isImportant,
             isMyDay: isMyDay,
-            listName: listName,
-            dueDate: dueDate
+            parsedDay: parsedDay
         )
     }
 
-    private static func normalizeToken(_ token: String) -> String {
-        token
-            .trimmingCharacters(in: .punctuationCharacters.subtracting(CharacterSet(charactersIn: "#@!:")))
-            .lowercased()
+    private static func tokenize(_ input: String) -> [TokenSlice] {
+        var result: [TokenSlice] = []
+        var idx = input.startIndex
+        while idx < input.endIndex {
+            while idx < input.endIndex, input[idx].isWhitespace {
+                idx = input.index(after: idx)
+            }
+            guard idx < input.endIndex else { break }
+
+            let start = idx
+            while idx < input.endIndex, !input[idx].isWhitespace {
+                idx = input.index(after: idx)
+            }
+            let end = idx
+            result.append(TokenSlice(raw: String(input[start..<end]), range: start..<end))
+        }
+        return result
     }
 
     private static func weekdayIndex(for token: String) -> Int? {
@@ -138,69 +153,26 @@ enum QuickAddNaturalLanguageParser {
         return calendar.date(byAdding: .day, value: delta, to: startOfToday)
     }
 
-    private static func parseTime(_ token: String) -> (hour: Int, minute: Int)? {
-        let cleaned = token.replacingOccurrences(of: ".", with: "")
-        let hasMeridiem = cleaned.hasSuffix("am") || cleaned.hasSuffix("pm")
-
-        let suffix: String?
-        let body: String
-        if hasMeridiem {
-            suffix = String(cleaned.suffix(2))
-            body = String(cleaned.dropLast(2))
-        } else {
-            suffix = nil
-            body = cleaned
-        }
-
-        guard !body.isEmpty else { return nil }
-        let segments = body.split(separator: ":")
-        guard segments.count == 1 || segments.count == 2 else { return nil }
-
-        guard let rawHour = Int(segments[0]) else { return nil }
-        let rawMinute: Int
-        if segments.count == 2 {
-            guard let minute = Int(segments[1]), (0...59).contains(minute) else { return nil }
-            rawMinute = minute
-        } else {
-            rawMinute = 0
-        }
-
-        if let suffix {
-            guard (1...12).contains(rawHour) else { return nil }
-            var hour = rawHour % 12
-            if suffix == "pm" {
-                hour += 12
-            }
-            return (hour: hour, minute: rawMinute)
-        }
-
-        guard (0...23).contains(rawHour) else { return nil }
-        return (hour: rawHour, minute: rawMinute)
-    }
-
     private static func resolveDueDate(
         day: Date?,
-        time: (hour: Int, minute: Int)?,
         now: Date,
         calendar: Calendar
     ) -> Date? {
-        guard day != nil || time != nil else { return nil }
-
-        let baseDay = day ?? calendar.startOfDay(for: now)
-        var components = calendar.dateComponents([.year, .month, .day], from: baseDay)
-        if let time {
-            components.hour = time.hour
-            components.minute = time.minute
-        } else {
-            components.hour = 0
-            components.minute = 0
-        }
-        components.second = 0
-
-        guard var due = calendar.date(from: components) else { return nil }
-        if day == nil, time != nil, due <= now {
-            due = calendar.date(byAdding: .day, value: 1, to: due) ?? due
-        }
-        return due
+        _ = now
+        guard let day else { return nil }
+        return day
     }
+}
+
+private struct TokenSlice {
+    let raw: String
+    let range: Range<String.Index>
+}
+
+private struct TokenAnalysis {
+    let tokens: [TokenSlice]
+    let consumed: Set<Int>
+    let isImportant: Bool
+    let isMyDay: Bool
+    let parsedDay: Date?
 }

--- a/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddHighlightingTextField.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddHighlightingTextField.swift
@@ -50,6 +50,7 @@ struct QuickAddHighlightingTextField: NSViewRepresentable {
         }
     }
 
+    @MainActor
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: QuickAddHighlightingTextField
         private var isProgrammaticChange = false

--- a/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddHighlightingTextField.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddHighlightingTextField.swift
@@ -1,0 +1,146 @@
+import AppKit
+import SwiftUI
+
+struct QuickAddHighlightingTextField: NSViewRepresentable {
+    @Binding var text: String
+    @Binding var isFocused: Bool
+
+    let placeholder: String
+    let highlightColor: NSColor
+    var nowProvider: () -> Date = Date.init
+    let onSubmit: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> NSTextField {
+        let field = NSTextField(string: "")
+        field.isBezeled = false
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.lineBreakMode = .byClipping
+        field.font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        field.delegate = context.coordinator
+        field.placeholderString = placeholder
+        field.maximumNumberOfLines = 1
+        field.cell?.usesSingleLineMode = true
+        field.cell?.wraps = false
+        context.coordinator.applyHighlight(to: field, text: text, preserveSelection: false)
+        return field
+    }
+
+    func updateNSView(_ nsView: NSTextField, context: Context) {
+        context.coordinator.parent = self
+        if nsView.stringValue != text {
+            context.coordinator.applyHighlight(to: nsView, text: text, preserveSelection: true)
+        }
+        if nsView.placeholderString != placeholder {
+            nsView.placeholderString = placeholder
+        }
+
+        guard let window = nsView.window else { return }
+        let firstResponder = window.firstResponder
+        let editor = nsView.currentEditor()
+        let isCurrentlyFocused = (firstResponder === nsView) || (editor != nil && firstResponder === editor)
+
+        if isFocused && !isCurrentlyFocused {
+            window.makeFirstResponder(nsView)
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: QuickAddHighlightingTextField
+        private var isProgrammaticChange = false
+
+        init(parent: QuickAddHighlightingTextField) {
+            self.parent = parent
+        }
+
+        func controlTextDidBeginEditing(_ obj: Notification) {
+            if !parent.isFocused {
+                parent.isFocused = true
+            }
+        }
+
+        func controlTextDidEndEditing(_ obj: Notification) {
+            if let field = obj.object as? NSTextField, field.currentEditor() != nil {
+                // Ignore transient end-edit callbacks caused by attributed-text refresh during active editing.
+                return
+            }
+            if parent.isFocused {
+                parent.isFocused = false
+            }
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard !isProgrammaticChange, let field = obj.object as? NSTextField else { return }
+            let newText = field.stringValue
+            if parent.text != newText {
+                parent.text = newText
+            }
+            if let editor = field.currentEditor() as? NSTextView, editor.hasMarkedText() {
+                return
+            }
+            applyHighlight(to: field, text: newText, preserveSelection: true)
+        }
+
+        func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+                parent.onSubmit()
+                return true
+            }
+            return false
+        }
+
+        func applyHighlight(to field: NSTextField, text: String, preserveSelection: Bool) {
+            let selectedRange = field.currentEditor()?.selectedRange
+            let attributed = NSMutableAttributedString(string: text)
+            let normalFont = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+            attributed.addAttributes(
+                [
+                    .font: normalFont,
+                    .foregroundColor: NSColor.textColor,
+                ],
+                range: NSRange(location: 0, length: attributed.length)
+            )
+
+            let ranges = QuickAddNaturalLanguageParser.highlightedTokenRanges(
+                in: text,
+                now: parent.nowProvider(),
+                calendar: .current
+            )
+            for range in ranges {
+                let nsRange = NSRange(range, in: text)
+                attributed.addAttributes(
+                    [
+                        .font: NSFont.systemFont(ofSize: NSFont.systemFontSize, weight: .semibold),
+                        .foregroundColor: parent.highlightColor,
+                    ],
+                    range: nsRange
+                )
+            }
+
+            isProgrammaticChange = true
+            if let editor = field.currentEditor() as? NSTextView {
+                editor.textStorage?.setAttributedString(attributed)
+                field.stringValue = text
+            } else {
+                field.attributedStringValue = attributed
+            }
+            isProgrammaticChange = false
+
+            if preserveSelection,
+               let editor = field.currentEditor(),
+               let selectedRange {
+                let maxLength = (text as NSString).length
+                let clampedLocation = min(selectedRange.location, maxLength)
+                let maxTail = max(0, maxLength - clampedLocation)
+                let clampedLength = min(selectedRange.length, maxTail)
+                editor.selectedRange = NSRange(location: clampedLocation, length: clampedLength)
+                editor.scrollRangeToVisible(editor.selectedRange)
+            }
+        }
+    }
+}

--- a/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddView.swift
@@ -10,6 +10,13 @@ struct QuickAddView: View {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    private var focusBinding: Binding<Bool> {
+        Binding(
+            get: { isInputFocused },
+            set: { isInputFocused = $0 }
+        )
+    }
+
     var body: some View {
         HStack(spacing: 10) {
             HStack(spacing: 8) {
@@ -18,10 +25,15 @@ struct QuickAddView: View {
                     .foregroundStyle(isInputFocused ? tokens.accentTerracotta : tokens.textTertiary)
                     .accessibilityHidden(true)
 
-                TextField("Add a task (⌘⇧N)", text: $text)
-                    .textFieldStyle(.plain)
-                    .focused($isInputFocused)
-                    .onSubmit(submit)
+                QuickAddHighlightingTextField(
+                    text: $text,
+                    isFocused: focusBinding,
+                    placeholder: "Add a task (⌘⇧N)",
+                    highlightColor: NSColor(tokens.accentTerracotta)
+                ) {
+                    submit()
+                }
+                .frame(height: 20)
                     .accessibilityLabel("Task title")
             }
             .padding(.horizontal, 12)
@@ -66,6 +78,7 @@ struct QuickAddView: View {
             .keyboardShortcut("n", modifiers: [.command, .shift])
             .opacity(0)
             .allowsHitTesting(false)
+            .accessibilityHidden(true)
         }
     }
 

--- a/macos/TodoFocusMac/Tests/CoreTests/QuickAddNaturalLanguageParserTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/QuickAddNaturalLanguageParserTests.swift
@@ -9,16 +9,15 @@ final class QuickAddNaturalLanguageParserTests: XCTestCase {
         return cal
     }
 
-    func testParsesFlagsListDateAndTimeAndStripsTokensFromTitle() throws {
+    func testParsesFlagsAndDateAndStripsTokensFromTitle() throws {
         let now = Date(timeIntervalSince1970: 1_763_520_000) // 2025-11-03T00:00:00Z
         let parsed = QuickAddNaturalLanguageParser.parse(
-            "ship desktop #Work ! @myday tomorrow 9:30am",
+            "ship desktop ! @myday tomorrow",
             now: now,
             calendar: calendar
         )
 
         XCTAssertEqual(parsed.title, "ship desktop")
-        XCTAssertEqual(parsed.listName, "Work")
         XCTAssertTrue(parsed.isImportant)
         XCTAssertTrue(parsed.isMyDay)
         XCTAssertNotNil(parsed.dueDate)
@@ -28,11 +27,11 @@ final class QuickAddNaturalLanguageParserTests: XCTestCase {
         let dueDay = calendar.startOfDay(for: due)
         XCTAssertEqual(dueDay, expectedDay)
         let components = calendar.dateComponents([.hour, .minute], from: due)
-        XCTAssertEqual(components.hour, 9)
-        XCTAssertEqual(components.minute, 30)
+        XCTAssertEqual(components.hour, 0)
+        XCTAssertEqual(components.minute, 0)
     }
 
-    func testTimeOnlySchedulesTomorrowWhenTimeAlreadyPassed() throws {
+    func testTimeTokenIsNotParsedAsDueDate() throws {
         let now = Date(timeIntervalSince1970: 1_763_552_400) // 2025-11-03T09:00:00Z
         let parsed = QuickAddNaturalLanguageParser.parse(
             "write report 8:00",
@@ -40,13 +39,8 @@ final class QuickAddNaturalLanguageParserTests: XCTestCase {
             calendar: calendar
         )
 
-        XCTAssertEqual(parsed.title, "write report")
-        let due = try XCTUnwrap(parsed.dueDate)
-        let expectedDay = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
-        XCTAssertEqual(calendar.startOfDay(for: due), expectedDay)
-        let components = calendar.dateComponents([.hour, .minute], from: due)
-        XCTAssertEqual(components.hour, 8)
-        XCTAssertEqual(components.minute, 0)
+        XCTAssertEqual(parsed.title, "write report 8:00")
+        XCTAssertNil(parsed.dueDate)
     }
 
     func testNoTokensKeepsTitleAndNoMetadata() {
@@ -60,7 +54,95 @@ final class QuickAddNaturalLanguageParserTests: XCTestCase {
         XCTAssertEqual(parsed.title, "plain task title")
         XCTAssertFalse(parsed.isImportant)
         XCTAssertFalse(parsed.isMyDay)
-        XCTAssertNil(parsed.listName)
         XCTAssertNil(parsed.dueDate)
+    }
+
+    func testHighlightedTokenRangesMatchRecognizedTokens() {
+        let now = Date(timeIntervalSince1970: 1_763_520_000)
+        let input = "ship #Work ! @myday tomorrow 9:30am !high"
+        let ranges = QuickAddNaturalLanguageParser.highlightedTokenRanges(in: input, now: now, calendar: calendar)
+        let tokens = ranges.map { String(input[$0]) }
+
+        XCTAssertEqual(tokens, ["!", "@myday", "tomorrow"])
+    }
+
+    func testHighlightedTokenRangesIncludeNextWeekPair() {
+        let now = Date(timeIntervalSince1970: 1_763_520_000)
+        let input = "prepare next week plan"
+        let ranges = QuickAddNaturalLanguageParser.highlightedTokenRanges(in: input, now: now, calendar: calendar)
+        let tokens = ranges.map { String(input[$0]) }
+
+        XCTAssertEqual(tokens, ["next", "week"])
+    }
+
+    func testHighlightedTokenRangesHandlePunctuationAndWhitespace() {
+        let now = Date(timeIntervalSince1970: 1_763_520_000)
+        let input = " \ttomorrow,\n#Work)\t!high  tomorrow: 9:30am:"
+        let ranges = QuickAddNaturalLanguageParser.highlightedTokenRanges(in: input, now: now, calendar: calendar)
+        let tokens = ranges.map { String(input[$0]) }
+
+        XCTAssertEqual(tokens, ["tomorrow,", "tomorrow:"])
+    }
+
+    func testHighlightedTokenRangesHandleUnicodeGraphemes() {
+        let now = Date(timeIntervalSince1970: 1_763_520_000)
+        let input = "计划🚀 tomorrow 9am"
+        let ranges = QuickAddNaturalLanguageParser.highlightedTokenRanges(in: input, now: now, calendar: calendar)
+        let tokens = ranges.map { String(input[$0]) }
+
+        XCTAssertEqual(tokens, ["tomorrow"])
+    }
+
+    func testParseUsesLastRecognizedTokenForConflicts() throws {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+        let now = Date(timeIntervalSince1970: 1_763_552_400) // 2025-11-03T09:00:00Z
+        let parsed = QuickAddNaturalLanguageParser.parse(
+            "ship today tomorrow",
+            now: now,
+            calendar: cal
+        )
+
+        XCTAssertEqual(parsed.title, "ship")
+        let due = try XCTUnwrap(parsed.dueDate)
+        let expectedDay = cal.date(byAdding: .day, value: 1, to: cal.startOfDay(for: now))
+        XCTAssertEqual(cal.startOfDay(for: due), expectedDay)
+        let components = cal.dateComponents([.hour, .minute], from: due)
+        XCTAssertEqual(components.hour, 0)
+        XCTAssertEqual(components.minute, 0)
+    }
+
+    func testParsePrecedenceBetweenNextWeekAndWeekdayUsesLastTokenWins() throws {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+        let now = try XCTUnwrap(
+            cal.date(from: DateComponents(year: 2025, month: 11, day: 5, hour: 9, minute: 0)) // Wednesday
+        )
+        let startOfToday = cal.startOfDay(for: now)
+
+        let parsedWeekdayLast = QuickAddNaturalLanguageParser.parse(
+            "plan next week monday",
+            now: now,
+            calendar: cal
+        )
+        let dueWeekdayLast = try XCTUnwrap(parsedWeekdayLast.dueDate)
+        let expectedMonday = try XCTUnwrap(cal.date(byAdding: .day, value: 5, to: startOfToday))
+        XCTAssertEqual(dueWeekdayLast, expectedMonday)
+
+        let parsedNextWeekLast = QuickAddNaturalLanguageParser.parse(
+            "plan monday next week",
+            now: now,
+            calendar: cal
+        )
+        let dueNextWeekLast = try XCTUnwrap(parsedNextWeekLast.dueDate)
+        let expectedNextWeek = try XCTUnwrap(cal.date(byAdding: .day, value: 7, to: startOfToday))
+        XCTAssertEqual(dueNextWeekLast, expectedNextWeek)
+
+        let highlighted = QuickAddNaturalLanguageParser.highlightedTokenRanges(
+            in: "plan monday next week",
+            now: now,
+            calendar: cal
+        ).map { String("plan monday next week"[$0]) }
+        XCTAssertEqual(highlighted, ["monday", "next", "week"])
     }
 }

--- a/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift
@@ -307,9 +307,14 @@ final class TodoAppStoreTests: XCTestCase {
         cal.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
         let now = Date(timeIntervalSince1970: 1_763_552_400) // 2025-11-03T09:00:00Z
         let (store, _, listRepository, todoRepository) = try makeStore(now: now)
-        let listRecord = try listRepository.createList(name: "Work", now: now)
+        let defaultListRecord = try listRepository.createList(name: "Fallback", now: now)
         try store.reload()
-        let defaultList = TodoList(id: "fallback", name: "Fallback", color: "#C46849", sortOrder: 0)
+        let defaultList = TodoList(
+            id: defaultListRecord.id,
+            name: defaultListRecord.name,
+            color: defaultListRecord.color,
+            sortOrder: defaultListRecord.sortOrder
+        )
 
         let created = try store.quickAddNaturalLanguage(
             input: "Ship release #Work ! @myday tomorrow 9:30am",
@@ -321,15 +326,15 @@ final class TodoAppStoreTests: XCTestCase {
         )
 
         let persisted = try XCTUnwrap(todoRepository.fetchTodo(id: created.id))
-        XCTAssertEqual(persisted.title, "Ship release")
+        XCTAssertEqual(persisted.title, "Ship release #Work 9:30am")
         XCTAssertTrue(persisted.isImportant)
         XCTAssertTrue(persisted.isMyDay)
-        XCTAssertEqual(persisted.listId, listRecord.id)
+        XCTAssertEqual(persisted.listId, defaultList.id)
         let expectedDay = cal.date(byAdding: .day, value: 1, to: cal.startOfDay(for: now))
         XCTAssertEqual(cal.startOfDay(for: try XCTUnwrap(persisted.dueDate)), expectedDay)
         let components = cal.dateComponents([.hour, .minute], from: try XCTUnwrap(persisted.dueDate))
-        XCTAssertEqual(components.hour, 9)
-        XCTAssertEqual(components.minute, 30)
+        XCTAssertEqual(components.hour, 0)
+        XCTAssertEqual(components.minute, 0)
     }
 
     func testUpdateNotesDebouncedPersistsLatestValue() throws {

--- a/macos/TodoFocusMac/TodoFocusMac.xcodeproj/project.pbxproj
+++ b/macos/TodoFocusMac/TodoFocusMac.xcodeproj/project.pbxproj
@@ -28,8 +28,8 @@
 		2488D4F86087E1711676B089 /* TimeFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDF00C67B73AFD0EEAD7E8C /* TimeFilterTests.swift */; };
 		268444DAD5DD06F74FABDF31 /* QuickCapturePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCDE1A9D59AEFBB5E780485 /* QuickCapturePanel.swift */; };
 		268C75C1B8CFC0C6F9D5083B /* TodoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC2D82AE6A92695B56A24B3 /* TodoRepository.swift */; };
-			28ACC25618CB3B0DD094C485 /* QuickAddNaturalLanguageParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28871DC8EDACA8A843BBC9B2 /* QuickAddNaturalLanguageParserTests.swift */; };
-			2996E34CF83FB29C7CCF0500 /* DeepFocusTemplateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2CD5B74E5D46555A530C5A /* DeepFocusTemplateStoreTests.swift */; };
+		28ACC25618CB3B0DD094C485 /* QuickAddNaturalLanguageParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28871DC8EDACA8A843BBC9B2 /* QuickAddNaturalLanguageParserTests.swift */; };
+		2996E34CF83FB29C7CCF0500 /* DeepFocusTemplateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2CD5B74E5D46555A530C5A /* DeepFocusTemplateStoreTests.swift */; };
 		2A77C39A5E1C252544AB40F1 /* LaunchResourceEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE07B39987D458DF0BF2B7D5 /* LaunchResourceEditorView.swift */; };
 		2A88F26958747C1D0F5262B7 /* AgentHeartbeatRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B848CBBD747A4848B0FA8 /* AgentHeartbeatRecord.swift */; };
 		2C0D092C397234106188359E /* TimeFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00F7F32AC8B9D5FF79A2F67 /* TimeFilter.swift */; };
@@ -100,6 +100,7 @@
 		D2F5C48FDC857B3D6D2B6E36 /* ImmersiveHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CECDF3CE43A5D8655A27316 /* ImmersiveHeaderView.swift */; };
 		D47CCAA280BB56FC203BAE6E /* ExportModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1A2C850F597AAD8E6B8A1F /* ExportModels.swift */; };
 		D489F9042CFCB3B6DA49ED59 /* Migrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6C2B13C8E141A41A721EB9 /* Migrations.swift */; };
+		D5FCC9B4E8D47AE6534C5EA4 /* QuickAddHighlightingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E4D16A9DE70FBFF43904EE /* QuickAddHighlightingTextField.swift */; };
 		DCB7C1425FC4D7CA492383F8 /* ShortcutHintBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5633165F8175CAD2AB7A90 /* ShortcutHintBar.swift */; };
 		E2B1C6CACAC71BF0FDFA8FAC /* HardFocusIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB028DBEA94826E11F650EB4 /* HardFocusIntegrationTests.swift */; };
 		E63935763D57E7925754DA11 /* StepRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7843ACD1FCEFBCAE938562 /* StepRecord.swift */; };
@@ -196,6 +197,7 @@
 		4BC65359FCD8A661E494F8E6 /* QuickAddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAddView.swift; sourceTree = "<group>"; };
 		4CECDF3CE43A5D8655A27316 /* ImmersiveHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmersiveHeaderView.swift; sourceTree = "<group>"; };
 		515BEFC0401BABD096FDF98D /* ListRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListRecord.swift; sourceTree = "<group>"; };
+		52E4D16A9DE70FBFF43904EE /* QuickAddHighlightingTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAddHighlightingTextField.swift; sourceTree = "<group>"; };
 		557C0A5FAD5A80348079DDAA /* MotionTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionTokens.swift; sourceTree = "<group>"; };
 		5CC15A3652F4971562B5E623 /* TodoRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoRecord.swift; sourceTree = "<group>"; };
 		6500EEE2BFADD6031680B52E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -494,6 +496,7 @@
 		964C4DFBDEC79E3BBAC06184 /* TaskList */ = {
 			isa = PBXGroup;
 			children = (
+				52E4D16A9DE70FBFF43904EE /* QuickAddHighlightingTextField.swift */,
 				4BC65359FCD8A661E494F8E6 /* QuickAddView.swift */,
 				30D5FE3587E551AA2AF551C4 /* TaskListView.swift */,
 				EA83C04DBE6BA2D4990E7C67 /* TodoRowView.swift */,
@@ -818,6 +821,7 @@
 				1B29CD200852FFA0C2032B8F /* ListRepository.swift in Sources */,
 				A0FBDFF3B725B51B7F153995 /* Migrations.swift in Sources */,
 				FD5051CB1C64B7911DF6CF3E /* MotionTokens.swift in Sources */,
+				D5FCC9B4E8D47AE6534C5EA4 /* QuickAddHighlightingTextField.swift in Sources */,
 				6623B1AB16AF877951B1083A /* QuickAddNaturalLanguageParser.swift in Sources */,
 				A06641EBAC9429CF7A200652 /* QuickAddView.swift in Sources */,
 				268444DAD5DD06F74FABDF31 /* QuickCapturePanel.swift in Sources */,


### PR DESCRIPTION
# PR: Quick Add Highlighting Stability + NL Token Rule Simplification

## Summary
- replace Quick Add overlay highlighting with AppKit-backed attributed input to keep caret/focus behavior stable
- fix focus-loss regression when typing in Quick Add input
- simplify natural-language token rules per product direction:
  - remove time parsing/highlighting (`9am`, `9:30am`, `21:15`)
  - remove `!high` token (keep `!` only)
  - remove `#list` parsing/highlighting
- update parser/store tests for new expected behavior and precedence coverage

## Files
- `macos/TodoFocusMac/Sources/Features/TaskList/QuickAddHighlightingTextField.swift` (new)
- `macos/TodoFocusMac/Sources/Features/TaskList/QuickAddView.swift`
- `macos/TodoFocusMac/Sources/Core/Parsing/QuickAddNaturalLanguageParser.swift`
- `macos/TodoFocusMac/Sources/App/TodoAppStore.swift`
- `macos/TodoFocusMac/Tests/CoreTests/QuickAddNaturalLanguageParserTests.swift`
- `macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift`
- docs artifacts under `docs/superpowers/{issues,plans}`

## Verification
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`
