### PR TITLE
fix(macOS): stabilize quick shortcuts and focus lifecycle

### DIFF
--- a/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
+++ b/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
@@ -71,7 +71,9 @@ final class QuickCaptureService {
                 object: nil,
                 queue: .main
             ) { [weak self] _ in
-                self?.refreshAccessibilityAndHotkey()
+                Task { @MainActor [weak self] in
+                    self?.refreshAccessibilityAndHotkey()
+                }
             }
         }
 

--- a/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
+++ b/macos/TodoFocusMac/Sources/App/QuickCaptureService.swift
@@ -3,6 +3,10 @@ import Observation
 import AVFoundation
 import Speech
 
+extension Notification.Name {
+    static let todoFocusQuickAddFocusRequested = Notification.Name("todoFocusQuickAddFocusRequested")
+}
+
 @Observable
 @MainActor
 final class QuickCaptureService {
@@ -27,6 +31,7 @@ final class QuickCaptureService {
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private var appDidBecomeActiveObserver: NSObjectProtocol?
     @ObservationIgnored private let audioEngine = AVAudioEngine()
     @ObservationIgnored private var recognitionRequests: [String: SFSpeechAudioBufferRecognitionRequest] = [:]
     @ObservationIgnored private var recognitionTasks: [String: SFSpeechRecognitionTask] = [:]
@@ -38,20 +43,48 @@ final class QuickCaptureService {
     @ObservationIgnored private var isCleaningUpHotkey: Bool = false
 
     func setup() {
-        checkAndRequestAccessibility()
-        setupGlobalHotkey()
+        ensureLifecycleObservers()
+        refreshAccessibilityAndHotkey()
     }
 
-    private func checkAndRequestAccessibility() {
+    private func refreshAccessibilityAndHotkey() {
         let trusted = AXIsProcessTrusted()
-        if !trusted {
-            needsAccessibilityPermission = true
+        needsAccessibilityPermission = !trusted
+        if trusted {
+            setupGlobalHotkey()
+        } else {
+            isHotkeyReady = false
         }
     }
 
     func requestAccessibilityPermission() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
             NSWorkspace.shared.open(url)
+        }
+        scheduleAccessibilityRecheck()
+    }
+
+    private func ensureLifecycleObservers() {
+        if appDidBecomeActiveObserver == nil {
+            appDidBecomeActiveObserver = NotificationCenter.default.addObserver(
+                forName: NSApplication.didBecomeActiveNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.refreshAccessibilityAndHotkey()
+            }
+        }
+
+    }
+
+    private func scheduleAccessibilityRecheck(attemptsRemaining: Int = 6) {
+        guard attemptsRemaining > 0 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+            guard let self else { return }
+            self.refreshAccessibilityAndHotkey()
+            if self.needsAccessibilityPermission {
+                self.scheduleAccessibilityRecheck(attemptsRemaining: attemptsRemaining - 1)
+            }
         }
     }
 
@@ -68,16 +101,36 @@ final class QuickCaptureService {
             guard let refcon = refcon else { return Unmanaged.passUnretained(event) }
             let service = Unmanaged<QuickCaptureService>.fromOpaque(refcon).takeUnretainedValue()
 
+            if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                DispatchQueue.main.async {
+                    if let existingTap = service.eventTap {
+                        CGEvent.tapEnable(tap: existingTap, enable: true)
+                    }
+                }
+                return Unmanaged.passUnretained(event)
+            }
+
             if type == .keyDown {
                 let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
                 let flags = event.flags
 
                 let hasCmd = flags.contains(.maskCommand)
                 let hasShift = flags.contains(.maskShift)
+                let charsIgnoringModifiers = NSEvent(cgEvent: event)?.charactersIgnoringModifiers?.lowercased() ?? ""
 
-                if hasCmd && hasShift && keyCode == 17 {
-                    Task { @MainActor in
+                let isQuickCaptureKey = charsIgnoringModifiers == "t" || keyCode == 17
+
+                if hasCmd && hasShift && isQuickCaptureKey {
+                    DispatchQueue.main.async {
                         service.showCapturePanel()
+                    }
+                    return nil
+                }
+
+                let isQuickAddKey = charsIgnoringModifiers == "n" || keyCode == 45
+                if hasCmd && hasShift && isQuickAddKey && NSApp.isActive {
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: .todoFocusQuickAddFocusRequested, object: nil)
                     }
                     return nil
                 }
@@ -436,6 +489,10 @@ final class QuickCaptureService {
         if let eventTap = eventTap {
             CFMachPortInvalidate(eventTap)
         }
+        if let observer = appDidBecomeActiveObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        appDidBecomeActiveObserver = nil
         eventTap = nil
         runLoopSource = nil
         isHotkeyReady = false

--- a/macos/TodoFocusMac/Sources/Features/Common/ShortcutHintBar.swift
+++ b/macos/TodoFocusMac/Sources/Features/Common/ShortcutHintBar.swift
@@ -86,7 +86,10 @@ struct ShortcutHintBarModifier: ViewModifier {
 }
 
 extension View {
-    func shortcutHintBar(needsAccessibilityPermission: Bool = false, onRequestPermission: (() -> Void)? = nil) -> some View {
+    func shortcutHintBar(
+        needsAccessibilityPermission: Bool = false,
+        onRequestPermission: (() -> Void)? = nil
+    ) -> some View {
         modifier(ShortcutHintBarModifier(
             needsAccessibilityPermission: needsAccessibilityPermission,
             onRequestPermission: onRequestPermission

--- a/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddHighlightingTextField.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddHighlightingTextField.swift
@@ -27,6 +27,7 @@ struct QuickAddHighlightingTextField: NSViewRepresentable {
         field.maximumNumberOfLines = 1
         field.cell?.usesSingleLineMode = true
         field.cell?.wraps = false
+        context.coordinator.attachField(field)
         context.coordinator.applyHighlight(to: field, text: text, preserveSelection: false)
         return field
     }
@@ -54,9 +55,27 @@ struct QuickAddHighlightingTextField: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: QuickAddHighlightingTextField
         private var isProgrammaticChange = false
+        private weak var field: NSTextField?
+        private var quickAddFocusObserver: NSObjectProtocol?
 
         init(parent: QuickAddHighlightingTextField) {
             self.parent = parent
+        }
+
+        func attachField(_ field: NSTextField) {
+            self.field = field
+            if quickAddFocusObserver == nil {
+                quickAddFocusObserver = NotificationCenter.default.addObserver(
+                    forName: .todoFocusQuickAddFocusRequested,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    guard let self, let field = self.field else { return }
+                    if let window = field.window ?? NSApp.keyWindow ?? NSApp.mainWindow {
+                        window.makeFirstResponder(field)
+                    }
+                }
+            }
         }
 
         func controlTextDidBeginEditing(_ obj: Notification) {

--- a/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddHighlightingTextField.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddHighlightingTextField.swift
@@ -70,9 +70,11 @@ struct QuickAddHighlightingTextField: NSViewRepresentable {
                     object: nil,
                     queue: .main
                 ) { [weak self] _ in
-                    guard let self, let field = self.field else { return }
-                    if let window = field.window ?? NSApp.keyWindow ?? NSApp.mainWindow {
-                        window.makeFirstResponder(field)
+                    Task { @MainActor [weak self] in
+                        guard let self, let field = self.field else { return }
+                        if let window = field.window ?? NSApp.keyWindow ?? NSApp.mainWindow {
+                            window.makeFirstResponder(field)
+                        }
                     }
                 }
             }

--- a/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/QuickAddView.swift
@@ -80,6 +80,12 @@ struct QuickAddView: View {
             .allowsHitTesting(false)
             .accessibilityHidden(true)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .todoFocusQuickAddFocusRequested)) { _ in
+            isInputFocused = false
+            DispatchQueue.main.async {
+                isInputFocused = true
+            }
+        }
     }
 
     private func submit() {

--- a/macos/TodoFocusMac/Sources/RootView.swift
+++ b/macos/TodoFocusMac/Sources/RootView.swift
@@ -113,9 +113,6 @@ struct RootView: View {
                 }
                 appModel.quickCaptureService.setup()
             }
-            .onDisappear {
-                appModel.quickCaptureService.cleanup()
-            }
             .onChange(of: proxy.size.width) { _, newValue in
                 containerWidth = newValue
                 appModel.updateDetailPanelWidth(appModel.detailPanelWidth, windowWidth: newValue)

--- a/macos/TodoFocusMac/Sources/TodoFocusMacApp.swift
+++ b/macos/TodoFocusMac/Sources/TodoFocusMacApp.swift
@@ -80,6 +80,7 @@ struct TodoFocusMacApp: App {
                     .themeMode(themeStore.theme)
                     .task {
                         appDelegate.onTerminateRequested = { [weak store] in
+                            appModel.quickCaptureService.cleanup()
                             await store?.endFocusForAppTermination()
                         }
                     }


### PR DESCRIPTION
## Summary
- keep global shortcut lifecycle at app-level instead of window lifecycle (prevent hotkey teardown when main window disappears)
- make Quick Capture hotkey matching layout-aware for Cmd+Shift+T by checking charactersIgnoringModifiers (t) with keycode fallback
- add Cmd+Shift+N handling in global hotkey path and route it to Quick Add focus via app notification
- make Quick Add focus landing deterministic by requesting first responder directly on the underlying NSTextField
- remove temporary debugging UI/diagnostic counters used during root-cause isolation

## Verification
- xcodegen generate
- xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
  - ** TEST SUCCEEDED **
- xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"
  - ** BUILD SUCCEEDED **
