### PR TITLE
🎨 Palette: Enhance TaskDetail flow and improve accessibility

### DIFF
--- a/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
@@ -147,6 +147,8 @@ struct SidebarView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(newListName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .accessibilityLabel("Confirm add list")
+                .help("Confirm add list")
 
                 Button {
                     withAnimation(.easeInOut(duration: 0.15)) {
@@ -159,6 +161,8 @@ struct SidebarView: View {
                         .foregroundStyle(tokens.textTertiary)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Cancel add list")
+                .help("Cancel add list")
             }
 
             colorPickerRow(selectedColor: $newListColor)
@@ -397,6 +401,8 @@ private struct SidebarListItemView: View {
                         .foregroundStyle(tokens.accentTerracotta)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Confirm rename list")
+                .help("Confirm rename list")
 
                 Button {
                     editingListId = nil
@@ -407,6 +413,8 @@ private struct SidebarListItemView: View {
                         .foregroundStyle(tokens.textTertiary)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Cancel rename list")
+                .help("Cancel rename list")
             }
 
             colorPickerRow(selectedColor: $editingListColor)

--- a/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
@@ -152,13 +152,13 @@ struct TaskDetailView: View {
                     Image(systemName: todo.isCompleted ? "checkmark.circle.fill" : "circle")
                         .font(.system(size: 17, weight: .semibold))
                         .padding(5)
-                        .background(todo.isCompleted ? Color.green.opacity(0.22) : Color.white.opacity(0.12), in: Circle())
+                        .background(todo.isCompleted ? tokens.success.opacity(0.22) : tokens.textPrimary.opacity(0.12), in: Circle())
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(todo.isCompleted ? Color.green : Color.white.opacity(0.94))
+                .foregroundStyle(todo.isCompleted ? tokens.success : tokens.textPrimary.opacity(0.94))
                 .overlay {
                     Circle()
-                        .stroke(Color.white.opacity(todo.isCompleted ? 0.10 : 0.20), lineWidth: 1)
+                        .stroke(tokens.textPrimary.opacity(todo.isCompleted ? 0.10 : 0.20), lineWidth: 1)
                         .padding(2)
                 }
                 .accessibilityLabel(todo.isCompleted ? "Mark as not completed" : "Mark as completed")

--- a/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
@@ -145,7 +145,25 @@ struct TaskDetailView: View {
         let titleGlowOpacity: Double = (isTitleFocused && !hasValidationError) ? 0.10 : 0
 
         return VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
+            HStack(spacing: 12) {
+                Button {
+                    try? store.toggleComplete(todoId: todo.id)
+                } label: {
+                    Image(systemName: todo.isCompleted ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 17, weight: .semibold))
+                        .padding(5)
+                        .background(todo.isCompleted ? Color.green.opacity(0.22) : Color.white.opacity(0.12), in: Circle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(todo.isCompleted ? Color.green : Color.white.opacity(0.94))
+                .overlay {
+                    Circle()
+                        .stroke(Color.white.opacity(todo.isCompleted ? 0.10 : 0.20), lineWidth: 1)
+                        .padding(2)
+                }
+                .accessibilityLabel(todo.isCompleted ? "Mark as not completed" : "Mark as completed")
+                .help(todo.isCompleted ? "Mark as not completed" : "Mark as completed")
+
                 VStack(alignment: .leading, spacing: 6) {
                     TextField("Task title", text: $titleText)
                         .textFieldStyle(.plain)
@@ -592,6 +610,8 @@ struct StepsEditorView: View {
                     .foregroundStyle(step.isCompleted ? tokens.success : tokens.textTertiary)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel(step.isCompleted ? "Mark step as not completed" : "Mark step as completed")
+            .help(step.isCompleted ? "Mark step as not completed" : "Mark step as completed")
 
             Text(step.title)
                 .font(.subheadline)

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TodoRowView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TodoRowView.swift
@@ -2,14 +2,15 @@ import SwiftUI
 
 struct DebtBadge: View {
     let timeString: String
+    @Environment(\.themeTokens) private var tokens
 
     var body: some View {
         Text("Overdue \(timeString)")
             .font(.caption2.weight(.medium))
-            .foregroundStyle(Color.red)
+            .foregroundStyle(tokens.danger)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(Color.red.opacity(0.12))
+            .background(tokens.danger.opacity(0.12))
             .cornerRadius(4)
     }
 }


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility enhancements to TodoFocus:

1.  **TaskDetail Completion Toggle**: A checkmark button is now available in the `TaskDetailView` header, right next to the task title. This provides a more convenient way to complete tasks while reviewing their details or notes.
2.  **Accessibility Labels & Tooltips**: Added `accessibilityLabel` and `.help()` modifiers to several icon-only buttons that previously lacked them:
    *   Step completion/checkmark buttons in `TaskDetailView`.
    *   Confirm (checkmark) and Cancel (xmark) buttons during list creation and renaming in the `SidebarView`.
3.  **Theme Consistency**: The `DebtBadge` (used for overdue tasks) has been updated to use the theme's `danger` color token instead of a hardcoded `Color.red`, ensuring it adapts correctly to the current theme.

♿ **Accessibility**: These changes ensure that icon-only buttons are properly announced by screen readers and provide helpful tooltips for all users.


---
*PR created automatically by Jules for task [3674734558147055416](https://jules.google.com/task/3674734558147055416) started by @michaelmjhhhh*