### PR TITLE
🎨 Palette: Semantic Color & Contrast Polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,7 +1,3 @@
 ## 2025-05-15 - [Consistent Icon-Only Button Accessibility]
 **Learning:** Icon-only buttons in the existing codebase often lacked either `.accessibilityLabel` (for screen readers) or `.help` (for tooltips), leading to inconsistent UX for different input methods.
 **Action:** When adding or modifying icon-only buttons, always include both `.accessibilityLabel` and `.help` to ensure full accessibility and discoverability. For toggle states, ensure the labels and tooltips are dynamic and reflect the current state (e.g., "Mark as completed" vs "Mark as not completed").
-
-## 2025-05-16 - [Semantic Color Tokens vs Hardcoded Colors]
-**Learning:** Hardcoded colors like `Color.white` or `Color.green` do not adapt to theme changes, leading to poor contrast or unreadable text (e.g., white text on white background) in Light Mode.
-**Action:** Always use semantic tokens from the `@Environment(\.themeTokens)` (e.g., `tokens.textPrimary`, `tokens.success`, `tokens.danger`) instead of raw SwiftUI colors. This ensures accessibility, consistent contrast, and seamless theme transitions.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - [Consistent Icon-Only Button Accessibility]
 **Learning:** Icon-only buttons in the existing codebase often lacked either `.accessibilityLabel` (for screen readers) or `.help` (for tooltips), leading to inconsistent UX for different input methods.
 **Action:** When adding or modifying icon-only buttons, always include both `.accessibilityLabel` and `.help` to ensure full accessibility and discoverability. For toggle states, ensure the labels and tooltips are dynamic and reflect the current state (e.g., "Mark as completed" vs "Mark as not completed").
+
+## 2025-05-16 - [Semantic Color Tokens vs Hardcoded Colors]
+**Learning:** Hardcoded colors like `Color.white` or `Color.green` do not adapt to theme changes, leading to poor contrast or unreadable text (e.g., white text on white background) in Light Mode.
+**Action:** Always use semantic tokens from the `@Environment(\.themeTokens)` (e.g., `tokens.textPrimary`, `tokens.success`, `tokens.danger`) instead of raw SwiftUI colors. This ensures accessibility, consistent contrast, and seamless theme transitions.

--- a/macos/TodoFocusMac/Sources/Features/Common/InteractiveStyles.swift
+++ b/macos/TodoFocusMac/Sources/Features/Common/InteractiveStyles.swift
@@ -2,11 +2,12 @@ import SwiftUI
 
 struct AppIconButtonStyle: ButtonStyle {
     var isEmphasized: Bool = false
+    @Environment(\.themeTokens) private var tokens
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .padding(6)
-            .background((isEmphasized ? Color.white.opacity(0.15) : Color.white.opacity(0.08)), in: RoundedRectangle(cornerRadius: 8))
+            .background((isEmphasized ? tokens.textPrimary.opacity(0.15) : tokens.textPrimary.opacity(0.08)), in: RoundedRectangle(cornerRadius: 8))
             .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
             .opacity(configuration.isPressed ? 0.88 : 1.0)
             .animation(MotionTokens.quickDuration == 0 ? .none : MotionTokens.hoverEase, value: configuration.isPressed)
@@ -22,14 +23,14 @@ struct RowStateModifier: ViewModifier {
         let isActive = isHovered || isSelected
         content
             .background(
-                (isSelected ? Color.white.opacity(0.20) : Color.white.opacity(isHovered ? 0.10 : 0.04)),
+                (isSelected ? tokens.textPrimary.opacity(0.20) : tokens.textPrimary.opacity(isHovered ? 0.10 : 0.04)),
                 in: RoundedRectangle(cornerRadius: 8)
             )
             .overlay {
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(
                         isSelected
-                            ? Color.white.opacity(0.22)
+                            ? tokens.textPrimary.opacity(0.22)
                             : tokens.sectionBorder.opacity(isActive ? 0.95 : 0),
                         lineWidth: isSelected ? 1.2 : 1
                     )

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -133,7 +133,7 @@ struct DailyReviewView: View {
                         .foregroundStyle(tokens.textSecondary)
                     Text(title)
                         .font(.headline.weight(.semibold))
-                        .foregroundStyle(Color.white)
+                        .foregroundStyle(tokens.textPrimary)
                     Text("\(columns.reduce(0) { $0 + $1.todos.count })")
                         .font(.caption.weight(.bold))
                         .monospacedDigit()
@@ -402,7 +402,7 @@ struct DailyReviewView: View {
                 Text(title)
             }
             .font(.caption.weight(.semibold))
-            .foregroundStyle(emphasize ? Color.white : tokens.textSecondary)
+            .foregroundStyle(emphasize ? tokens.textPrimary : tokens.textSecondary)
             .padding(.horizontal, compact ? 9 : 11)
             .padding(.vertical, compact ? 5 : 7)
             .background((emphasize ? tokens.accentTerracotta.opacity(0.95) : tokens.bgFloating.opacity(0.8)), in: Capsule())

--- a/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
@@ -134,10 +134,10 @@ struct TaskDetailView: View {
         let hasValidationError = titleValidationMessage != nil
         let titleStrokeColor: Color = {
             if hasValidationError {
-                return Color.red.opacity(0.70)
+                return tokens.danger.opacity(0.70)
             }
             if isTitleFocused {
-                return Color.white.opacity(0.26)
+                return tokens.textPrimary.opacity(0.26)
             }
             return tokens.sectionBorder.opacity(0.70)
         }()
@@ -163,7 +163,7 @@ struct TaskDetailView: View {
                     if let titleValidationMessage {
                         Text(titleValidationMessage)
                             .font(.caption)
-                            .foregroundStyle(Color.red.opacity(0.92))
+                            .foregroundStyle(tokens.danger.opacity(0.92))
                             .transition(.opacity.combined(with: .move(edge: .top)))
                     }
                 }
@@ -179,10 +179,10 @@ struct TaskDetailView: View {
                 }
                 .overlay {
                     RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.white.opacity(titleGlowOpacity), lineWidth: 4)
+                        .stroke(tokens.textPrimary.opacity(titleGlowOpacity), lineWidth: 4)
                         .blur(radius: 0.4)
                 }
-                .shadow(color: hasValidationError ? Color.red.opacity(0.16) : .clear, radius: 6)
+                .shadow(color: hasValidationError ? tokens.danger.opacity(0.16) : .clear, radius: 6)
                 .animation(MotionTokens.focusEase, value: isTitleFocused)
                 .animation(MotionTokens.validationEase, value: hasValidationError)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -196,7 +196,7 @@ struct TaskDetailView: View {
                             Text(store.deepFocusService.isActive ? "Focus Running" : "Deep Focus")
                                 .font(.subheadline.weight(.medium))
                         }
-                        .foregroundStyle(.white)
+                        .foregroundStyle(tokens.textPrimary)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
                         .background(

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TodoRowView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TodoRowView.swift
@@ -2,14 +2,15 @@ import SwiftUI
 
 struct DebtBadge: View {
     let timeString: String
+    @Environment(\.themeTokens) private var tokens
 
     var body: some View {
         Text("Overdue \(timeString)")
             .font(.caption2.weight(.medium))
-            .foregroundStyle(Color.red)
+            .foregroundStyle(tokens.danger)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(Color.red.opacity(0.12))
+            .background(tokens.danger.opacity(0.12))
             .cornerRadius(4)
     }
 }
@@ -36,7 +37,7 @@ struct TodoRowView: View {
 
     private var indicatorColor: Color {
         if todo.isImportant {
-            return .yellow
+            return tokens.accentAmber
         }
         return listColor ?? tokens.accentTerracotta
     }
@@ -51,13 +52,13 @@ struct TodoRowView: View {
                 Image(systemName: todo.isCompleted ? "checkmark.circle.fill" : "circle")
                     .font(.system(size: 17, weight: .semibold))
                     .padding(5)
-                    .background(todo.isCompleted ? Color.green.opacity(0.22) : Color.white.opacity(0.12), in: Circle())
+                    .background(todo.isCompleted ? tokens.success.opacity(0.22) : tokens.textPrimary.opacity(0.12), in: Circle())
             }
             .buttonStyle(.plain)
-            .foregroundStyle(todo.isCompleted ? Color.green : Color.white.opacity(0.94))
+            .foregroundStyle(todo.isCompleted ? tokens.success : tokens.textPrimary.opacity(0.94))
             .overlay {
                 Circle()
-                    .stroke(Color.white.opacity(todo.isCompleted ? 0.10 : 0.20), lineWidth: 1)
+                    .stroke(tokens.textPrimary.opacity(todo.isCompleted ? 0.10 : 0.20), lineWidth: 1)
                     .padding(2)
             }
             .accessibilityLabel(todo.isCompleted ? "Mark as not completed" : "Mark as completed")
@@ -67,7 +68,7 @@ struct TodoRowView: View {
                 Text(todo.title)
                     .strikethrough(todo.isCompleted)
                     .font(.body.weight(todo.isCompleted ? .regular : .medium))
-                    .foregroundStyle(isSelected ? Color.white : .primary)
+                    .foregroundStyle(isSelected ? tokens.textPrimary : .primary)
                 if let dueDate = todo.dueDate {
                     Label {
                         Text(dueDate, style: .date)
@@ -75,7 +76,7 @@ struct TodoRowView: View {
                         Image(systemName: "calendar")
                     }
                     .font(.caption2)
-                    .foregroundStyle(isSelected ? Color.white.opacity(0.82) : tokens.mutedText)
+                    .foregroundStyle(isSelected ? tokens.textPrimary.opacity(0.82) : tokens.mutedText)
                 }
                 if todo.isOverdue {
                     DebtBadge(timeString: store.formatDebt(todo.debtSeconds ?? 0))
@@ -89,7 +90,7 @@ struct TodoRowView: View {
                     Image(systemName: todo.isImportant ? "star.fill" : "star")
                 }
                 .buttonStyle(AppIconButtonStyle())
-                .foregroundStyle(todo.isImportant ? Color.yellow : tokens.mutedText)
+                .foregroundStyle(todo.isImportant ? tokens.accentAmber : tokens.mutedText)
                 .accessibilityLabel(todo.isImportant ? "Mark as not important" : "Mark as important")
                 .help(todo.isImportant ? "Mark as not important" : "Mark as important")
 


### PR DESCRIPTION
### 🎨 Palette: Semantic Color & Contrast Polish

#### 💡 What: 
Migrated hardcoded SwiftUI colors (`Color.red`, `Color.white`, `.yellow`, `Color.green`) to semantic theme tokens (`tokens.danger`, `tokens.textPrimary`, `tokens.accentAmber`, `tokens.success`).

#### 🎯 Why: 
Hardcoded colors like `Color.white` for text were unreadable in Light Mode (white text on white background) and did not follow the app's established theme system. This change ensures visual consistency and maintainability.

#### ♿ Accessibility: 
- Improved contrast for overdue badges and error messages using `tokens.danger`.
- Fixed unreadable text in `DailyReviewView` lane headers for Light Mode.
- Ensured consistent hover and selection states in `TaskListView` and `SidebarView`.

---
*PR created automatically by Jules for task [5550349801139597755](https://jules.google.com/task/5550349801139597755) started by @michaelmjhhhh*