### PR TITLE
🎨 Palette: Improve icon-only button accessibility

### DIFF
--- a/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
@@ -401,8 +401,8 @@ private struct SidebarListItemView: View {
                         .foregroundStyle(tokens.accentTerracotta)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Confirm rename")
-                .help("Confirm rename")
+                .accessibilityLabel("Confirm rename list")
+                .help("Confirm rename list")
 
                 Button {
                     editingListId = nil
@@ -413,8 +413,8 @@ private struct SidebarListItemView: View {
                         .foregroundStyle(tokens.textTertiary)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Cancel rename")
-                .help("Cancel rename")
+                .accessibilityLabel("Cancel rename list")
+                .help("Cancel rename list")
             }
 
             colorPickerRow(selectedColor: $editingListColor)

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
@@ -146,6 +146,8 @@ struct SidebarView: View {
                         .foregroundStyle(tokens.accentTerracotta)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Confirm add list")
+                .help("Confirm add list")
                 .disabled(newListName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
                 Button {
@@ -159,6 +161,8 @@ struct SidebarView: View {
                         .foregroundStyle(tokens.textTertiary)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Cancel add list")
+                .help("Cancel add list")
             }
 
             colorPickerRow(selectedColor: $newListColor)
@@ -397,6 +401,8 @@ private struct SidebarListItemView: View {
                         .foregroundStyle(tokens.accentTerracotta)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Confirm rename")
+                .help("Confirm rename")
 
                 Button {
                     editingListId = nil
@@ -407,6 +413,8 @@ private struct SidebarListItemView: View {
                         .foregroundStyle(tokens.textTertiary)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Cancel rename")
+                .help("Cancel rename")
             }
 
             colorPickerRow(selectedColor: $editingListColor)

--- a/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
@@ -592,6 +592,8 @@ struct StepsEditorView: View {
                     .foregroundStyle(step.isCompleted ? tokens.success : tokens.textTertiary)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel(step.isCompleted ? "Mark step as not completed" : "Mark step as completed")
+            .help(step.isCompleted ? "Mark step as not completed" : "Mark step as completed")
 
             Text(step.title)
                 .font(.subheadline)

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
@@ -215,6 +215,7 @@ struct TaskListView: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Clear search")
+                    .help("Clear search")
                     .transition(.opacity.combined(with: .scale(scale: 0.9)))
                 }
             }


### PR DESCRIPTION
This change improves the accessibility and discoverability of several icon-only buttons across the application. 

Key improvements:
- TaskDetailView: Step completion buttons now have dynamic labels and tooltips that reflect the current state (e.g., "Mark step as completed" vs "Mark step as not completed").
- TaskListView: The search clear button now has a tooltip ("Clear search"), complementing its existing accessibility label.
- SidebarView: The checkmark and xmark buttons for adding and renaming lists now have both accessibility labels and tooltips (e.g., "Confirm add list", "Cancel rename").

These small changes ensure a more intuitive experience for users who use assistive technologies or rely on tooltips for discoverability.

---
*PR created automatically by Jules for task [390026288944001193](https://jules.google.com/task/390026288944001193) started by @michaelmjhhhh*