### PR TITLE
🎨 Palette: Improve color picker accessibility and tooltips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - [Consistent Icon-Only Button Accessibility]
 **Learning:** Icon-only buttons in the existing codebase often lacked either `.accessibilityLabel` (for screen readers) or `.help` (for tooltips), leading to inconsistent UX for different input methods.
 **Action:** When adding or modifying icon-only buttons, always include both `.accessibilityLabel` and `.help` to ensure full accessibility and discoverability. For toggle states, ensure the labels and tooltips are dynamic and reflect the current state (e.g., "Mark as completed" vs "Mark as not completed").
+
+## 2025-05-16 - [Accessible Color Swatches]
+**Learning:** Using `.onTapGesture` on decorative shapes (like `Circle`) makes them inaccessible to keyboard users and silent to screen readers.
+**Action:** Always wrap interactive color swatches in a `Button` with `.buttonStyle(.plain)` and provide an `accessibilityLabel` and `.help` tooltip. Center the mapping of hex codes to names in a utility like `ListColor` to ensure consistency.

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/ListColor.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/ListColor.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct ListColor {
+    static func name(for hex: String) -> String {
+        switch hex.uppercased() {
+        case "#EF4444": return "Red"
+        case "#F97316": return "Orange"
+        case "#EAB308": return "Yellow"
+        case "#22C55E": return "Green"
+        case "#06B6D4": return "Cyan"
+        case "#3B82F6": return "Blue"
+        case "#8B5CF6": return "Violet"
+        case "#EC4899": return "Pink"
+        case "#6366F1": return "Indigo"
+        case "#14B8A6": return "Teal"
+        default: return "Custom Color"
+        }
+    }
+}

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
@@ -170,21 +170,26 @@ struct SidebarView: View {
     private func colorPickerRow(selectedColor: Binding<String>) -> some View {
         HStack(spacing: 6) {
             ForEach(availableColors, id: \.self) { colorHex in
-                Circle()
-                    .fill(Color(hex: colorHex))
-                    .frame(width: 16, height: 16)
-                    .overlay {
-                        if selectedColor.wrappedValue == colorHex {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 8, weight: .bold))
-                                .foregroundStyle(.white)
-                        }
+                Button {
+                    withAnimation(.easeInOut(duration: 0.1)) {
+                        selectedColor.wrappedValue = colorHex
                     }
-                    .onTapGesture {
-                        withAnimation(.easeInOut(duration: 0.1)) {
-                            selectedColor.wrappedValue = colorHex
+                } label: {
+                    Circle()
+                        .fill(Color(hex: colorHex))
+                        .frame(width: 16, height: 16)
+                        .overlay {
+                            if selectedColor.wrappedValue == colorHex {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 8, weight: .bold))
+                                    .foregroundStyle(.white)
+                                    .accessibilityHidden(true)
+                            }
                         }
-                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(ListColor.name(for: colorHex))
+                .help(ListColor.name(for: colorHex))
             }
         }
     }
@@ -418,21 +423,26 @@ private struct SidebarListItemView: View {
     private func colorPickerRow(selectedColor: Binding<String>) -> some View {
         HStack(spacing: 6) {
             ForEach(Self.availableColors, id: \.self) { colorHex in
-                Circle()
-                    .fill(Color(hex: colorHex))
-                    .frame(width: 16, height: 16)
-                    .overlay {
-                        if selectedColor.wrappedValue == colorHex {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 8, weight: .bold))
-                                .foregroundStyle(.white)
-                        }
+                Button {
+                    withAnimation(.easeInOut(duration: 0.1)) {
+                        selectedColor.wrappedValue = colorHex
                     }
-                    .onTapGesture {
-                        withAnimation(.easeInOut(duration: 0.1)) {
-                            selectedColor.wrappedValue = colorHex
+                } label: {
+                    Circle()
+                        .fill(Color(hex: colorHex))
+                        .frame(width: 16, height: 16)
+                        .overlay {
+                            if selectedColor.wrappedValue == colorHex {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 8, weight: .bold))
+                                    .foregroundStyle(.white)
+                                    .accessibilityHidden(true)
+                            }
                         }
-                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(ListColor.name(for: colorHex))
+                .help(ListColor.name(for: colorHex))
             }
         }
     }


### PR DESCRIPTION
### 💡 What:
Refactored the color picker in the sidebar and list editing views to use standard SwiftUI `Button` components instead of gestures on circles. Added accessibility labels and tooltips for all colors.

### 🎯 Why:
Previously, the color picker was inaccessible to keyboard users and screen readers. Users with color vision deficiencies had no way to identify colors besides their visual representation. Standard buttons ensure the UI is navigable by keyboard and provides proper semantic context to assistive technologies.

### ♿ Accessibility Improvements:
- **Keyboard Navigation:** Interactive color swatches are now semantic buttons and participate in the tab order.
- **Screen Reader Support:** Added `accessibilityLabel` with human-readable color names (e.g., "Teal", "Indigo") using a new `ListColor` utility.
- **Discoverability:** Added `.help` tooltips to show color names on hover.
- **Clean Hierarchy:** Hid redundant selection checkmark icons from assistive technologies using `.accessibilityHidden(true)`.

---
*PR created automatically by Jules for task [9730597494227246943](https://jules.google.com/task/9730597494227246943) started by @michaelmjhhhh*