### PR TITLE
🎨 Palette: Sidebar Accessibility & Interactivity Enhancements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - [Consistent Icon-Only Button Accessibility]
 **Learning:** Icon-only buttons in the existing codebase often lacked either `.accessibilityLabel` (for screen readers) or `.help` (for tooltips), leading to inconsistent UX for different input methods.
 **Action:** When adding or modifying icon-only buttons, always include both `.accessibilityLabel` and `.help` to ensure full accessibility and discoverability. For toggle states, ensure the labels and tooltips are dynamic and reflect the current state (e.g., "Mark as completed" vs "Mark as not completed").
+
+## 2025-05-22 - [Accessible Color Swatches and Keyboard Navigation]
+**Learning:** Using `.onTapGesture` on shapes like `Circle` makes them inaccessible to keyboard users and screen readers on macOS. Mapping Tailwind-based hex codes to semantic names (e.g., "#EF4444" to "Red") is essential for providing meaningful accessibility labels for visual-only controls like color pickers.
+**Action:** Always implement interactive swatches as `Button` elements with `.buttonStyle(.plain)` and use a centralized utility like `ListColor` to provide descriptive labels and tooltips.

--- a/macos/TodoFocusMac/Sources/Features/Common/ImmersiveHeaderView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Common/ImmersiveHeaderView.swift
@@ -44,6 +44,8 @@ struct ImmersiveHeaderView: View {
         }
         .buttonStyle(.plain)
         .opacity(isExpanded ? 1 : 0)
+        .accessibilityLabel(isSidebarVisible ? "Hide sidebar" : "Show sidebar")
+        .help(isSidebarVisible ? "Hide sidebar" : "Show sidebar")
     }
 }
 

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/ListColor.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/ListColor.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum ListColor {
+    static func name(for hex: String) -> String {
+        switch hex.uppercased() {
+        case "#EF4444": return "Red"
+        case "#F97316": return "Orange"
+        case "#EAB308": return "Yellow"
+        case "#22C55E": return "Green"
+        case "#06B6D4": return "Cyan"
+        case "#3B82F6": return "Blue"
+        case "#8B5CF6": return "Violet"
+        case "#EC4899": return "Pink"
+        case "#6366F1": return "Indigo"
+        case "#14B8A6": return "Teal"
+        default: return "Custom Color"
+        }
+    }
+}

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
@@ -114,6 +114,8 @@ struct SidebarView: View {
             }
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Add new list")
+        .help("Add new list")
     }
 
     private var addingListRow: some View {
@@ -170,21 +172,25 @@ struct SidebarView: View {
     private func colorPickerRow(selectedColor: Binding<String>) -> some View {
         HStack(spacing: 6) {
             ForEach(availableColors, id: \.self) { colorHex in
-                Circle()
-                    .fill(Color(hex: colorHex))
-                    .frame(width: 16, height: 16)
-                    .overlay {
-                        if selectedColor.wrappedValue == colorHex {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 8, weight: .bold))
-                                .foregroundStyle(.white)
-                        }
+                Button {
+                    withAnimation(.easeInOut(duration: 0.1)) {
+                        selectedColor.wrappedValue = colorHex
                     }
-                    .onTapGesture {
-                        withAnimation(.easeInOut(duration: 0.1)) {
-                            selectedColor.wrappedValue = colorHex
+                } label: {
+                    Circle()
+                        .fill(Color(hex: colorHex))
+                        .frame(width: 16, height: 16)
+                        .overlay {
+                            if selectedColor.wrappedValue == colorHex {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 8, weight: .bold))
+                                    .foregroundStyle(.white)
+                            }
                         }
-                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(ListColor.name(for: colorHex))
+                .help(ListColor.name(for: colorHex))
             }
         }
     }
@@ -418,21 +424,25 @@ private struct SidebarListItemView: View {
     private func colorPickerRow(selectedColor: Binding<String>) -> some View {
         HStack(spacing: 6) {
             ForEach(Self.availableColors, id: \.self) { colorHex in
-                Circle()
-                    .fill(Color(hex: colorHex))
-                    .frame(width: 16, height: 16)
-                    .overlay {
-                        if selectedColor.wrappedValue == colorHex {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 8, weight: .bold))
-                                .foregroundStyle(.white)
-                        }
+                Button {
+                    withAnimation(.easeInOut(duration: 0.1)) {
+                        selectedColor.wrappedValue = colorHex
                     }
-                    .onTapGesture {
-                        withAnimation(.easeInOut(duration: 0.1)) {
-                            selectedColor.wrappedValue = colorHex
+                } label: {
+                    Circle()
+                        .fill(Color(hex: colorHex))
+                        .frame(width: 16, height: 16)
+                        .overlay {
+                            if selectedColor.wrappedValue == colorHex {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 8, weight: .bold))
+                                    .foregroundStyle(.white)
+                            }
                         }
-                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(ListColor.name(for: colorHex))
+                .help(ListColor.name(for: colorHex))
             }
         }
     }


### PR DESCRIPTION
This PR introduces micro-UX and accessibility enhancements to the Sidebar.

💡 What:
- Refactored the color picker (for both new and existing lists) to use `Button` elements instead of `.onTapGesture` on circles.
- Added a `ListColor` utility to map Tailwind hex codes to semantic names for screen readers and tooltips.
- Added dynamic accessibility labels and help text to the sidebar toggle button.
- Added accessibility labels and tooltips to the "Add list" button.

🎯 Why:
- Previous implementation of color swatches was not keyboard-navigable or screen-reader friendly.
- Icon-only buttons lacked discoverability for non-mouse users.
- The sidebar toggle didn't reflect its state to assistive technologies.

♿ Accessibility:
- Full keyboard navigation for list color selection.
- Screen reader support for list colors (e.g., "Red", "Indigo") instead of just "Button".
- State-aware labels for structural UI toggles.

---
*PR created automatically by Jules for task [15862376373586785156](https://jules.google.com/task/15862376373586785156) started by @michaelmjhhhh*