### PR TITLE
🎨 Palette: Improve accessibility and UX of list color picker

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - [Consistent Icon-Only Button Accessibility]
 **Learning:** Icon-only buttons in the existing codebase often lacked either `.accessibilityLabel` (for screen readers) or `.help` (for tooltips), leading to inconsistent UX for different input methods.
 **Action:** When adding or modifying icon-only buttons, always include both `.accessibilityLabel` and `.help` to ensure full accessibility and discoverability. For toggle states, ensure the labels and tooltips are dynamic and reflect the current state (e.g., "Mark as completed" vs "Mark as not completed").
+
+## 2025-05-16 - [Accessible Color Swatches]
+**Learning:** Interactive shapes using `.onTapGesture` are not keyboard-accessible and lack semantic roles for screen readers. Using a `Button` with `.buttonStyle(.plain)` provides these for free.
+**Action:** Always implement interactive swatches or items as `Button` elements. Use a centralized utility (like `ListColor`) to map hex codes to human-readable names for `.accessibilityLabel` and `.help`.

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/ListColor.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/ListColor.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct ListColor: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let hex: String
+
+    init(name: String, hex: String) {
+        self.id = hex
+        self.name = name
+        self.hex = hex
+    }
+
+    static let all: [ListColor] = [
+        ListColor(name: "Red", hex: "#EF4444"),
+        ListColor(name: "Orange", hex: "#F97316"),
+        ListColor(name: "Yellow", hex: "#EAB308"),
+        ListColor(name: "Green", hex: "#22C55E"),
+        ListColor(name: "Cyan", hex: "#06B6D4"),
+        ListColor(name: "Blue", hex: "#3B82F6"),
+        ListColor(name: "Violet", hex: "#8B5CF6"),
+        ListColor(name: "Pink", hex: "#EC4899"),
+        ListColor(name: "Indigo", hex: "#6366F1"),
+        ListColor(name: "Teal", hex: "#14B8A6")
+    ]
+
+    static func name(for hex: String) -> String {
+        all.first(where: { $0.hex.uppercased() == hex.uppercased() })?.name ?? "Custom Color"
+    }
+}

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
@@ -13,11 +13,6 @@ struct SidebarView: View {
     @State private var editingListName: String = ""
     @State private var editingListColor: String = "#6366F1"
 
-    private let availableColors: [String] = [
-        "#EF4444", "#F97316", "#EAB308", "#22C55E", "#06B6D4",
-        "#3B82F6", "#8B5CF6", "#EC4899", "#6366F1", "#14B8A6"
-    ]
-
     var body: some View {
         List {
             Section {
@@ -169,22 +164,26 @@ struct SidebarView: View {
 
     private func colorPickerRow(selectedColor: Binding<String>) -> some View {
         HStack(spacing: 6) {
-            ForEach(availableColors, id: \.self) { colorHex in
-                Circle()
-                    .fill(Color(hex: colorHex))
-                    .frame(width: 16, height: 16)
-                    .overlay {
-                        if selectedColor.wrappedValue == colorHex {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 8, weight: .bold))
-                                .foregroundStyle(.white)
-                        }
+            ForEach(ListColor.all) { color in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.1)) {
+                        selectedColor.wrappedValue = color.hex
                     }
-                    .onTapGesture {
-                        withAnimation(.easeInOut(duration: 0.1)) {
-                            selectedColor.wrappedValue = colorHex
+                } label: {
+                    Circle()
+                        .fill(Color(hex: color.hex))
+                        .frame(width: 16, height: 16)
+                        .overlay {
+                            if selectedColor.wrappedValue == color.hex {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 8, weight: .bold))
+                                    .foregroundStyle(.white)
+                            }
                         }
-                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(color.name)
+                .help(color.name)
             }
         }
     }
@@ -315,11 +314,6 @@ private struct SidebarListItemView: View {
     @Binding var editingListColor: String
     @Environment(\.themeTokens) private var tokens
 
-    private static let availableColors: [String] = [
-        "#EF4444", "#F97316", "#EAB308", "#22C55E", "#06B6D4",
-        "#3B82F6", "#8B5CF6", "#EC4899", "#6366F1", "#14B8A6"
-    ]
-
     var body: some View {
         if isEditing {
             listEditRow
@@ -417,22 +411,26 @@ private struct SidebarListItemView: View {
 
     private func colorPickerRow(selectedColor: Binding<String>) -> some View {
         HStack(spacing: 6) {
-            ForEach(Self.availableColors, id: \.self) { colorHex in
-                Circle()
-                    .fill(Color(hex: colorHex))
-                    .frame(width: 16, height: 16)
-                    .overlay {
-                        if selectedColor.wrappedValue == colorHex {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 8, weight: .bold))
-                                .foregroundStyle(.white)
-                        }
+            ForEach(ListColor.all) { color in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.1)) {
+                        selectedColor.wrappedValue = color.hex
                     }
-                    .onTapGesture {
-                        withAnimation(.easeInOut(duration: 0.1)) {
-                            selectedColor.wrappedValue = colorHex
+                } label: {
+                    Circle()
+                        .fill(Color(hex: color.hex))
+                        .frame(width: 16, height: 16)
+                        .overlay {
+                            if selectedColor.wrappedValue == color.hex {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 8, weight: .bold))
+                                    .foregroundStyle(.white)
+                            }
                         }
-                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(color.name)
+                .help(color.name)
             }
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced `onTapGesture` on color circles with proper `Button` elements and centralized color definitions.

🎯 **Why:** The previous implementation was not keyboard-accessible and provided no context to screen readers. Using `Button` with `.buttonStyle(.plain)` makes the color picker part of the tab order, while adding labels ensures all users know what color they are selecting.

♿ **Accessibility:** 
- Added `.accessibilityLabel` (e.g., "Indigo") for screen readers.
- Added `.help` (tooltips) for hover feedback.
- Ensured keyboard navigation support for color selection.

Centralizing the colors in `ListColor.swift` also removed duplicated color lists in the sidebar code.

---
*PR created automatically by Jules for task [9471124675234089849](https://jules.google.com/task/9471124675234089849) started by @michaelmjhhhh*