### PR TITLE
🎨 Palette: Improve color picker accessibility and deduplicate code

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - [Consistent Icon-Only Button Accessibility]
 **Learning:** Icon-only buttons in the existing codebase often lacked either `.accessibilityLabel` (for screen readers) or `.help` (for tooltips), leading to inconsistent UX for different input methods.
 **Action:** When adding or modifying icon-only buttons, always include both `.accessibilityLabel` and `.help` to ensure full accessibility and discoverability. For toggle states, ensure the labels and tooltips are dynamic and reflect the current state (e.g., "Mark as completed" vs "Mark as not completed").
+
+## 2025-05-16 - [Accessible Color Pickers]
+**Learning:** Interactive color swatches implemented with `onTapGesture` on shapes are not accessible to keyboard users or screen readers.
+**Action:** Always implement color swatches as `Button` elements with `.buttonStyle(.plain)`. Centralize the color palette in a utility (e.g., `ListColor`) that provides semantic names for each hex code to be used in `.accessibilityLabel()` and `.help()` modifiers.

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/ListColor.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/ListColor.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct ListColor: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let color: Color
+
+    init(hex: String, name: String) {
+        self.id = hex
+        self.name = name
+        self.color = Color(hex: hex)
+    }
+
+    static let all: [ListColor] = [
+        ListColor(hex: "#EF4444", name: "Red"),
+        ListColor(hex: "#F97316", name: "Orange"),
+        ListColor(hex: "#EAB308", name: "Yellow"),
+        ListColor(hex: "#22C55E", name: "Green"),
+        ListColor(hex: "#06B6D4", name: "Cyan"),
+        ListColor(hex: "#3B82F6", name: "Blue"),
+        ListColor(hex: "#8B5CF6", name: "Violet"),
+        ListColor(hex: "#EC4899", name: "Pink"),
+        ListColor(hex: "#6366F1", name: "Indigo"),
+        ListColor(hex: "#14B8A6", name: "Teal")
+    ]
+
+    static func name(for hex: String) -> String {
+        all.first(where: { $0.id == hex })?.name ?? "Custom Color"
+    }
+}

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
@@ -13,11 +13,6 @@ struct SidebarView: View {
     @State private var editingListName: String = ""
     @State private var editingListColor: String = "#6366F1"
 
-    private let availableColors: [String] = [
-        "#EF4444", "#F97316", "#EAB308", "#22C55E", "#06B6D4",
-        "#3B82F6", "#8B5CF6", "#EC4899", "#6366F1", "#14B8A6"
-    ]
-
     var body: some View {
         List {
             Section {
@@ -161,32 +156,10 @@ struct SidebarView: View {
                 .buttonStyle(.plain)
             }
 
-            colorPickerRow(selectedColor: $newListColor)
+            ColorPickerRow(selectedColor: $newListColor)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
-    }
-
-    private func colorPickerRow(selectedColor: Binding<String>) -> some View {
-        HStack(spacing: 6) {
-            ForEach(availableColors, id: \.self) { colorHex in
-                Circle()
-                    .fill(Color(hex: colorHex))
-                    .frame(width: 16, height: 16)
-                    .overlay {
-                        if selectedColor.wrappedValue == colorHex {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 8, weight: .bold))
-                                .foregroundStyle(.white)
-                        }
-                    }
-                    .onTapGesture {
-                        withAnimation(.easeInOut(duration: 0.1)) {
-                            selectedColor.wrappedValue = colorHex
-                        }
-                    }
-            }
-        }
     }
 
     private func commitAddList() {
@@ -315,11 +288,6 @@ private struct SidebarListItemView: View {
     @Binding var editingListColor: String
     @Environment(\.themeTokens) private var tokens
 
-    private static let availableColors: [String] = [
-        "#EF4444", "#F97316", "#EAB308", "#22C55E", "#06B6D4",
-        "#3B82F6", "#8B5CF6", "#EC4899", "#6366F1", "#14B8A6"
-    ]
-
     var body: some View {
         if isEditing {
             listEditRow
@@ -409,32 +377,10 @@ private struct SidebarListItemView: View {
                 .buttonStyle(.plain)
             }
 
-            colorPickerRow(selectedColor: $editingListColor)
+            ColorPickerRow(selectedColor: $editingListColor)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
-    }
-
-    private func colorPickerRow(selectedColor: Binding<String>) -> some View {
-        HStack(spacing: 6) {
-            ForEach(Self.availableColors, id: \.self) { colorHex in
-                Circle()
-                    .fill(Color(hex: colorHex))
-                    .frame(width: 16, height: 16)
-                    .overlay {
-                        if selectedColor.wrappedValue == colorHex {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 8, weight: .bold))
-                                .foregroundStyle(.white)
-                        }
-                    }
-                    .onTapGesture {
-                        withAnimation(.easeInOut(duration: 0.1)) {
-                            selectedColor.wrappedValue = colorHex
-                        }
-                    }
-            }
-        }
     }
 
     private var renameList: Void {
@@ -446,5 +392,36 @@ private struct SidebarListItemView: View {
         store.renameList(listId: list.id, newName: trimmed, color: editingListColor)
         editingListId = nil
         editingListName = ""
+    }
+}
+
+private struct ColorPickerRow: View {
+    @Binding var selectedColor: String
+    @Environment(\.themeTokens) private var tokens
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(ListColor.all) { listColor in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.1)) {
+                        selectedColor = listColor.id
+                    }
+                } label: {
+                    Circle()
+                        .fill(listColor.color)
+                        .frame(width: 16, height: 16)
+                        .overlay {
+                            if selectedColor == listColor.id {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 8, weight: .bold))
+                                    .foregroundStyle(.white)
+                            }
+                        }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("\(listColor.name) color")
+                .help("\(listColor.name) color")
+            }
+        }
     }
 }


### PR DESCRIPTION
This change improves the accessibility and maintainability of the list color picker in the sidebar.

Key improvements:
- **Accessibility**: Color swatches are now focusable and navigable via keyboard by using `Button` instead of `onTapGesture`.
- **Screen Reader Support**: Each color now has a descriptive `accessibilityLabel` (e.g., "Red color").
- **Discoverability**: Added macOS tooltips (`.help`) so users can see the color names on hover.
- **Maintainability**: Centralized the Tailwind-based color palette into a new `ListColor` utility and refactored the duplicated picker logic into a shared `ColorPickerRow` component.

Verifications:
- Manually inspected code for correctness and adherence to SwiftUI/macOS patterns.
- Verified that all previous hardcoded hex arrays were replaced by the centralized `ListColor.all`.
- Confirmed that the new component is used in both the "Add List" and "Edit List" flows.

---
*PR created automatically by Jules for task [4853845788935540444](https://jules.google.com/task/4853845788935540444) started by @michaelmjhhhh*