### PR TITLE
feat(macOS): add task archive management

### DIFF
--- a/macos/TodoFocusMac/Sources/App/AppModel.swift
+++ b/macos/TodoFocusMac/Sources/App/AppModel.swift
@@ -41,6 +41,8 @@ final class AppModel {
             return "overdue"
         case .all:
             return "all"
+        case .archive:
+            return "archive"
         case let .customList(id):
             return id
         }

--- a/macos/TodoFocusMac/Sources/App/SelectionState.swift
+++ b/macos/TodoFocusMac/Sources/App/SelectionState.swift
@@ -7,6 +7,7 @@ enum SidebarSelection: Equatable {
     case planned
     case overdue
     case all
+    case archive
     case customList(String)
 
     var smartList: SmartList {
@@ -23,6 +24,8 @@ enum SidebarSelection: Equatable {
             return .all
         case .all:
             return .all
+        case .archive:
+            return .archive
         case let .customList(id):
             return .custom(listId: id)
         }

--- a/macos/TodoFocusMac/Sources/App/TodoAppStore.swift
+++ b/macos/TodoFocusMac/Sources/App/TodoAppStore.swift
@@ -17,17 +17,21 @@ final class TodoAppStore {
     var todos: [Todo] = []
     var mutationErrorMessage: String?
 
+    private var nonArchivedTodos: [Todo] { todos.filter { !$0.isArchived } }
+    var reviewTodos: [Todo] { nonArchivedTodos }
+
     var deepFocusService: DeepFocusService { appModel.deepFocusService }
     let hardFocusManager: HardFocusSessionManager
 
-    var todoCount: Int { todos.count }
-    var completedCount: Int { todos.filter { $0.isCompleted }.count }
-    var importantCount: Int { todos.filter { $0.isImportant }.count }
-    var myDayCount: Int { todos.filter { $0.isMyDay }.count }
-    var todayCount: Int { todos.filter { ($0.dueDate ?? .distantPast) < Date() && !$0.isCompleted }.count }
-    var plannedCount: Int { todos.filter { $0.dueDate != nil && !$0.isCompleted }.count }
-    var overdueCount: Int { todos.filter { $0.isOverdue }.count }
-    var totalOverdueDebtSeconds: Int { todos.compactMap { $0.debtSeconds }.reduce(0, +) }
+    var todoCount: Int { nonArchivedTodos.count }
+    var completedCount: Int { nonArchivedTodos.filter { $0.isCompleted }.count }
+    var importantCount: Int { nonArchivedTodos.filter { $0.isImportant }.count }
+    var myDayCount: Int { nonArchivedTodos.filter { $0.isMyDay }.count }
+    var todayCount: Int { nonArchivedTodos.filter { ($0.dueDate ?? .distantPast) < Date() && !$0.isCompleted }.count }
+    var plannedCount: Int { nonArchivedTodos.filter { $0.dueDate != nil && !$0.isCompleted }.count }
+    var overdueCount: Int { nonArchivedTodos.filter { $0.isOverdue }.count }
+    var archivedCount: Int { todos.filter { $0.isArchived }.count }
+    var totalOverdueDebtSeconds: Int { nonArchivedTodos.compactMap { $0.debtSeconds }.reduce(0, +) }
 
     func formatDebt(_ seconds: Int) -> String {
         if seconds < 60 {
@@ -47,7 +51,7 @@ final class TodoAppStore {
     }
 
     func countForList(_ listId: String) -> Int {
-        todos.filter { $0.listId == listId && !$0.isCompleted }.count
+        nonArchivedTodos.filter { $0.listId == listId && !$0.isCompleted }.count
     }
 
     init(
@@ -197,7 +201,13 @@ final class TodoAppStore {
         }
         var input = UpdateTodoInput()
         input.isCompleted = !current.isCompleted
+        if current.isArchived, current.isCompleted {
+            input.isArchived = false
+        }
         try todoRepository.updateTodo(id: todoId, input: input, now: now())
+        if current.isArchived, appModel.selectedTodoID == todoId {
+            appModel.selectedTodoID = nil
+        }
         try reloadTodos()
         // Play completion sound when marking as complete (not uncompleting)
         if !current.isCompleted {
@@ -208,6 +218,7 @@ final class TodoAppStore {
     func markComplete(todoId: String) throws {
         var input = UpdateTodoInput()
         input.isCompleted = true
+        input.isArchived = false
         try todoRepository.updateTodo(id: todoId, input: input, now: now())
         try reloadTodos()
         NSSound(named: NSSound.Name("Pop"))?.play()
@@ -232,9 +243,50 @@ final class TodoAppStore {
     }
 
     func clearCompletedTodos() throws {
-        let selectedTodoWasRemoved = selectedTodo?.isCompleted ?? false
-        _ = try todoRepository.clearCompletedTodos()
+        try clearCompletedTodos(todoIDs: nonArchivedTodos.filter(\.isCompleted).map(\.id))
+    }
+
+    func clearCompletedTodos(todoIDs: [String]) throws {
+        let selectedTodoWasArchived = selectedTodo?.isCompleted == true && selectedTodo?.isArchived == false
+        _ = try todoRepository.archiveCompletedTodos(ids: todoIDs, now: now())
+        if selectedTodoWasArchived {
+            appModel.selectedTodoID = nil
+        }
+        try reloadTodos()
+    }
+
+    func clearArchivedTodos() throws {
+        let selectedTodoWasRemoved = selectedTodo?.isArchived == true
+        _ = try todoRepository.clearArchivedTodos()
         if selectedTodoWasRemoved {
+            appModel.selectedTodoID = nil
+        }
+        try reloadTodos()
+    }
+
+    func archiveTodo(todoId: String) throws {
+        guard let current = try todoRepository.fetchTodo(id: todoId), current.isCompleted, !current.isArchived else {
+            return
+        }
+
+        var input = UpdateTodoInput()
+        input.isArchived = true
+        try todoRepository.updateTodo(id: todoId, input: input, now: now())
+        if appModel.selectedTodoID == todoId {
+            appModel.selectedTodoID = nil
+        }
+        try reloadTodos()
+    }
+
+    func unarchiveTodo(todoId: String) throws {
+        guard let current = try todoRepository.fetchTodo(id: todoId), current.isArchived else {
+            return
+        }
+
+        var input = UpdateTodoInput()
+        input.isArchived = false
+        try todoRepository.updateTodo(id: todoId, input: input, now: now())
+        if appModel.selectedTodoID == todoId {
             appModel.selectedTodoID = nil
         }
         try reloadTodos()
@@ -572,7 +624,15 @@ final class TodoAppStore {
 
 private extension Todo {
     var coreTodo: CoreTodo {
-        CoreTodo(id: id, isMyDay: isMyDay, isImportant: isImportant, isCompleted: isCompleted, dueDate: dueDate, listId: listId)
+        CoreTodo(
+            id: id,
+            isMyDay: isMyDay,
+            isImportant: isImportant,
+            isCompleted: isCompleted,
+            isArchived: isArchived,
+            dueDate: dueDate,
+            listId: listId
+        )
     }
 }
 
@@ -582,6 +642,7 @@ private extension TodoRecord {
             id: id,
             title: title,
             isCompleted: isCompleted,
+            isArchived: isArchived,
             isImportant: isImportant,
             isMyDay: isMyDay,
             dueDate: dueDate,

--- a/macos/TodoFocusMac/Sources/Core/Filters/SmartList.swift
+++ b/macos/TodoFocusMac/Sources/Core/Filters/SmartList.swift
@@ -5,21 +5,24 @@ enum SmartList: Equatable {
     case important
     case planned
     case all
+    case archive
     case custom(listId: String)
 }
 
 func filterTodos(_ todos: [CoreTodo], for smartList: SmartList) -> [CoreTodo] {
     switch smartList {
     case .myDay:
-        return todos.filter { $0.isMyDay }
+        return todos.filter { !$0.isArchived && $0.isMyDay }
     case .important:
-        return todos.filter { $0.isImportant }
+        return todos.filter { !$0.isArchived && $0.isImportant }
     case .planned:
-        return todos.filter { $0.dueDate != nil }
+        return todos.filter { !$0.isArchived && $0.dueDate != nil }
     case .all:
-        return todos
+        return todos.filter { !$0.isArchived }
+    case .archive:
+        return todos.filter { $0.isArchived }
     case let .custom(listId):
-        return todos.filter { $0.listId == listId }
+        return todos.filter { !$0.isArchived && $0.listId == listId }
     }
 }
 
@@ -32,6 +35,13 @@ func applyFilters(
 ) -> [CoreTodo] {
     let smartListFiltered = filterTodos(todos, for: smartList)
     return smartListFiltered.filter {
-        matchesTimeFilter(timeFilter, dueDate: $0.dueDate, isCompleted: $0.isCompleted, now: now, calendar: calendar)
+        matchesTimeFilter(
+            timeFilter,
+            dueDate: $0.dueDate,
+            isCompleted: $0.isCompleted,
+            isArchived: $0.isArchived,
+            now: now,
+            calendar: calendar
+        )
     }
 }

--- a/macos/TodoFocusMac/Sources/Core/Filters/TimeFilter.swift
+++ b/macos/TodoFocusMac/Sources/Core/Filters/TimeFilter.swift
@@ -36,6 +36,7 @@ func matches(
     filter: TimeFilter,
     dueDate: Date?,
     isCompleted: Bool,
+    isArchived: Bool,
     now: Date = Date(),
     calendar: Calendar = .current
 ) -> Bool {
@@ -54,7 +55,7 @@ func matches(
     let dayDiff = diffInLocalDays(from: now, to: dueDate, calendar: calendar)
 
     if filter == .overdue {
-        return !isCompleted && dayDiff < 0
+        return !isCompleted && !isArchived && dayDiff < 0
     }
 
     if filter == .today {
@@ -72,8 +73,9 @@ func matchesTimeFilter(
     _ filter: TimeFilter,
     dueDate: Date?,
     isCompleted: Bool,
+    isArchived: Bool,
     now: Date = Date(),
     calendar: Calendar = .current
 ) -> Bool {
-    matches(filter: filter, dueDate: dueDate, isCompleted: isCompleted, now: now, calendar: calendar)
+    matches(filter: filter, dueDate: dueDate, isCompleted: isCompleted, isArchived: isArchived, now: now, calendar: calendar)
 }

--- a/macos/TodoFocusMac/Sources/Core/Models/CoreTodo.swift
+++ b/macos/TodoFocusMac/Sources/Core/Models/CoreTodo.swift
@@ -5,6 +5,25 @@ struct CoreTodo: Equatable {
     let isMyDay: Bool
     let isImportant: Bool
     let isCompleted: Bool
+    let isArchived: Bool
     let dueDate: Date?
     let listId: String?
+
+    init(
+        id: String,
+        isMyDay: Bool,
+        isImportant: Bool,
+        isCompleted: Bool,
+        isArchived: Bool = false,
+        dueDate: Date?,
+        listId: String?
+    ) {
+        self.id = id
+        self.isMyDay = isMyDay
+        self.isImportant = isImportant
+        self.isCompleted = isCompleted
+        self.isArchived = isArchived
+        self.dueDate = dueDate
+        self.listId = listId
+    }
 }

--- a/macos/TodoFocusMac/Sources/Core/Models/Todo.swift
+++ b/macos/TodoFocusMac/Sources/Core/Models/Todo.swift
@@ -4,6 +4,7 @@ struct Todo: Identifiable, Equatable {
     let id: String
     var title: String
     var isCompleted: Bool
+    var isArchived: Bool = false
     var isImportant: Bool
     var isMyDay: Bool
     var dueDate: Date?
@@ -13,7 +14,7 @@ struct Todo: Identifiable, Equatable {
     var focusTimeSeconds: Int = 0
 
     func debtSeconds(at now: Date = Date(), calendar: Calendar = .current) -> Int? {
-        guard !isCompleted, let dueDate else { return nil }
+        guard !isCompleted, !isArchived, let dueDate else { return nil }
 
         // Due date is day-based in the UI, so a task should only become overdue
         // after the local due day has fully passed.

--- a/macos/TodoFocusMac/Sources/Data/DTO/TodoRecord.swift
+++ b/macos/TodoFocusMac/Sources/Data/DTO/TodoRecord.swift
@@ -7,6 +7,7 @@ struct TodoRecord: Codable, FetchableRecord, PersistableRecord, Equatable {
     var id: String
     var title: String
     var isCompleted: Bool
+    var isArchived: Bool = false
     var isImportant: Bool
     var isMyDay: Bool
     var recurrence: String?

--- a/macos/TodoFocusMac/Sources/Data/Database/Migrations.swift
+++ b/macos/TodoFocusMac/Sources/Data/Database/Migrations.swift
@@ -80,6 +80,11 @@ enum Migrations {
             )
         }
 
+        migrator.registerMigration("v4_archive_todos") { db in
+            try db.execute(sql: "ALTER TABLE todo ADD COLUMN isArchived BOOLEAN NOT NULL DEFAULT 0")
+            try db.create(index: "idx_todo_archived_completed_sort", on: "todo", columns: ["isArchived", "isCompleted", "sortOrder", "createdAt"])
+        }
+
         return migrator
     }
 }

--- a/macos/TodoFocusMac/Sources/Data/Export/ExportModels.swift
+++ b/macos/TodoFocusMac/Sources/Data/Export/ExportModels.swift
@@ -5,10 +5,11 @@ enum ExportFormatVersion {
     static let v1_1 = "1.1"
     static let v1_2 = "1.2"
     static let v1_3 = "1.3"
-    static let current = v1_3
+    static let v1_4 = "1.4"
+    static let current = v1_4
 
     static func isSupported(_ version: String) -> Bool {
-        version == v1_0 || version == v1_1 || version == v1_2 || version == v1_3
+        version == v1_0 || version == v1_1 || version == v1_2 || version == v1_3 || version == v1_4
     }
 }
 
@@ -37,6 +38,7 @@ struct ExportTodo: Codable {
     let id: String
     let title: String
     let isCompleted: Bool
+    let isArchived: Bool
     let isImportant: Bool
     let isMyDay: Bool
     let dueDate: Date?
@@ -58,6 +60,7 @@ extension ExportTodo {
         case id
         case title
         case isCompleted
+        case isArchived
         case isImportant
         case isMyDay
         case dueDate
@@ -79,6 +82,7 @@ extension ExportTodo {
         id = try container.decode(String.self, forKey: .id)
         title = try container.decode(String.self, forKey: .title)
         isCompleted = try container.decode(Bool.self, forKey: .isCompleted)
+        isArchived = try container.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false
         isImportant = try container.decode(Bool.self, forKey: .isImportant)
         isMyDay = try container.decode(Bool.self, forKey: .isMyDay)
         dueDate = try container.decodeIfPresent(Date.self, forKey: .dueDate)

--- a/macos/TodoFocusMac/Sources/Data/Export/ExportService.swift
+++ b/macos/TodoFocusMac/Sources/Data/Export/ExportService.swift
@@ -105,6 +105,7 @@ final class ExportService {
                     id: record.id,
                     title: record.title,
                     isCompleted: record.isCompleted,
+                    isArchived: record.isArchived,
                     isImportant: record.isImportant,
                     isMyDay: record.isMyDay,
                     dueDate: record.dueDate,
@@ -271,7 +272,8 @@ final class ExportService {
                 let record = TodoRecord(
                     id: todo.id,
                     title: todo.title,
-                    isCompleted: todo.isCompleted,
+                    isCompleted: todo.isCompleted || todo.isArchived,
+                    isArchived: todo.isArchived,
                     isImportant: todo.isImportant,
                     isMyDay: todo.isMyDay,
                     recurrence: todo.recurrence,

--- a/macos/TodoFocusMac/Sources/Data/Repositories/TodoRepository.swift
+++ b/macos/TodoFocusMac/Sources/Data/Repositories/TodoRepository.swift
@@ -12,6 +12,7 @@ struct AddTodoInput {
 struct UpdateTodoInput {
     var title: String?
     var isCompleted: Bool?
+    var isArchived: Bool?
     var isImportant: Bool?
     var isMyDay: Bool?
     var recurrence: String??
@@ -50,6 +51,7 @@ struct TodoRepository {
                 id: UUID().uuidString,
                 title: trimmedTitle,
                 isCompleted: false,
+                isArchived: false,
                 isImportant: input.isImportant,
                 isMyDay: input.isMyDay,
                 recurrence: nil,
@@ -86,6 +88,12 @@ struct TodoRepository {
             }
             if let isCompleted = input.isCompleted {
                 current.isCompleted = isCompleted
+                if !isCompleted {
+                    current.isArchived = false
+                }
+            }
+            if let isArchived = input.isArchived {
+                current.isArchived = isArchived
             }
             if let isImportant = input.isImportant {
                 current.isImportant = isImportant
@@ -121,6 +129,10 @@ struct TodoRepository {
             }
             if let focusTimeSeconds = input.focusTimeSeconds {
                 current.focusTimeSeconds = max(0, focusTimeSeconds)
+            }
+
+            if current.isArchived {
+                current.isCompleted = true
             }
 
             current.updatedAt = now
@@ -180,7 +192,43 @@ struct TodoRepository {
 
     func clearCompletedTodos() throws -> Int {
         try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM todo WHERE isCompleted = 1")
+            try db.execute(sql: "DELETE FROM todo WHERE isCompleted = 1 AND isArchived = 0")
+            return Int(db.changesCount)
+        }
+    }
+
+    func archiveCompletedTodos(now: Date = Date()) throws -> Int {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE todo SET isArchived = 1, updatedAt = ? WHERE isCompleted = 1 AND isArchived = 0",
+                arguments: [now]
+            )
+            return Int(db.changesCount)
+        }
+    }
+
+    func archiveCompletedTodos(ids: [String], now: Date = Date()) throws -> Int {
+        let uniqueIDs = Array(Set(ids))
+        guard !uniqueIDs.isEmpty else { return 0 }
+
+        return try dbQueue.write { db in
+            let placeholders = databaseQuestionMarks(count: uniqueIDs.count)
+            var arguments = StatementArguments()
+            arguments += [now]
+            for id in uniqueIDs {
+                arguments += [id]
+            }
+            try db.execute(
+                sql: "UPDATE todo SET isArchived = 1, updatedAt = ? WHERE isCompleted = 1 AND isArchived = 0 AND id IN (\(placeholders))",
+                arguments: arguments
+            )
+            return Int(db.changesCount)
+        }
+    }
+
+    func clearArchivedTodos() throws -> Int {
+        try dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM todo WHERE isArchived = 1")
             return Int(db.changesCount)
         }
     }
@@ -217,5 +265,9 @@ struct TodoRepository {
         case let .ok(serialized):
             return serialized
         }
+    }
+
+    private func databaseQuestionMarks(count: Int) -> String {
+        Array(repeating: "?", count: count).joined(separator: ", ")
     }
 }

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -45,7 +45,7 @@ struct DailyReviewView: View {
                 errorBanner(errorMessage)
             }
 
-            if store.todos.isEmpty {
+            if store.reviewTodos.isEmpty {
                 emptyState
             } else {
                 ScrollView {
@@ -75,10 +75,10 @@ struct DailyReviewView: View {
         }
         .padding(16)
         .onAppear {
-            boardViewModel.recompute(todos: store.todos)
+            boardViewModel.recompute(todos: store.reviewTodos)
         }
-        .onChange(of: store.todos) { _, newTodos in
-            boardViewModel.recompute(todos: newTodos)
+        .onChange(of: store.todos) { _, _ in
+            boardViewModel.recompute(todos: store.reviewTodos)
         }
     }
 

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
@@ -27,6 +27,7 @@ struct SidebarView: View {
                 smartRow("Planned", systemImage: "calendar", selection: .planned, count: store.plannedCount)
                 smartRow("Overdue", systemImage: "exclamationmark.triangle", selection: .overdue, count: store.overdueCount)
                 smartRow("All Tasks", systemImage: "tray.full", selection: .all, count: store.todoCount)
+                smartRow("Archive", systemImage: "archivebox", selection: .archive, count: store.archivedCount)
             }
 
             Section {

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
@@ -8,6 +8,7 @@ struct TaskListView: View {
     @State private var isCompletedCollapsed: Bool = false
     @State private var isCompletedPanelVisible: Bool = true
     @State private var showClearCompletedConfirmation: Bool = false
+    @State private var showEmptyArchiveConfirmation: Bool = false
     @State private var filteredTodosCache: [Todo] = []
     @State private var activeTodosCache: [Todo] = []
     @State private var completedTodosCache: [Todo] = []
@@ -52,7 +53,7 @@ struct TaskListView: View {
                         .font(.system(size: 18, weight: .semibold, design: .rounded))
                 }
                 Spacer()
-                if !isOverdueView {
+                if !isOverdueView && !isArchiveView {
                     filterPicker
                 }
 
@@ -68,65 +69,79 @@ struct TaskListView: View {
                             .stroke(tokens.sectionBorder.opacity(0.9), lineWidth: 1)
                     }
 
-                Button {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isCompletedPanelVisible.toggle()
+                if isArchiveView {
+                    Button(role: .destructive) {
+                        showEmptyArchiveConfirmation = true
+                    } label: {
+                        Text("Empty Archive")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(tokens.danger)
                     }
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: isCompletedPanelVisible ? "eye" : "eye.slash")
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(isCompletedPanelVisible ? tokens.accentTerracotta : tokens.textTertiary)
-                            .frame(width: 20, height: 20)
-                            .background(tokens.bgFloating.opacity(0.95), in: Circle())
-                        Text("Completed")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(isCompletedPanelVisible ? tokens.textSecondary : tokens.textTertiary)
-                        Text("\(completedTodosCache.count)")
-                            .font(.caption.weight(.semibold))
-                            .monospacedDigit()
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .foregroundStyle(isCompletedPanelVisible ? tokens.textPrimary : tokens.textSecondary)
-                            .background(tokens.bgFloating.opacity(0.95), in: Capsule())
+                    .buttonStyle(.plain)
+                    .disabled(filteredTodosCache.isEmpty)
+                } else {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isCompletedPanelVisible.toggle()
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: isCompletedPanelVisible ? "eye" : "eye.slash")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(isCompletedPanelVisible ? tokens.accentTerracotta : tokens.textTertiary)
+                                .frame(width: 20, height: 20)
+                                .background(tokens.bgFloating.opacity(0.95), in: Circle())
+                            Text("Completed")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(isCompletedPanelVisible ? tokens.textSecondary : tokens.textTertiary)
+                            Text("\(completedTodosCache.count)")
+                                .font(.caption.weight(.semibold))
+                                .monospacedDigit()
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .foregroundStyle(isCompletedPanelVisible ? tokens.textPrimary : tokens.textSecondary)
+                                .background(tokens.bgFloating.opacity(0.95), in: Capsule())
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(tokens.bgFloating.opacity(isCompletedPanelVisible ? 0.82 : 0.66), in: Capsule())
+                        .overlay {
+                            Capsule()
+                                .stroke(
+                                    isCompletedPanelVisible
+                                        ? tokens.accentTerracotta.opacity(0.28)
+                                        : tokens.sectionBorder.opacity(0.92),
+                                    lineWidth: 1
+                                )
+                        }
                     }
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(tokens.bgFloating.opacity(isCompletedPanelVisible ? 0.82 : 0.66), in: Capsule())
-                    .overlay {
-                        Capsule()
-                            .stroke(
-                                isCompletedPanelVisible
-                                    ? tokens.accentTerracotta.opacity(0.28)
-                                    : tokens.sectionBorder.opacity(0.92),
-                                lineWidth: 1
-                            )
-                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(isCompletedPanelVisible ? "Hide completed panel" : "Show completed panel")
+                    .help(isCompletedPanelVisible ? "Hide completed panel" : "Show completed panel")
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel(isCompletedPanelVisible ? "Hide completed panel" : "Show completed panel")
-                .help(isCompletedPanelVisible ? "Hide completed panel" : "Show completed panel")
             }
 
-            QuickAddView { title in
-                do {
-                    try store.quickAddNaturalLanguage(
-                        input: title,
-                        defaultPlanned: appModel.selection == .planned,
-                        defaultIsImportant: appModel.selection == .important,
-                        defaultIsMyDay: appModel.selection == .myDay,
-                        defaultList: selectedList
-                    )
-                } catch {
+            if !isArchiveView {
+                QuickAddView { title in
+                    do {
+                        try store.quickAddNaturalLanguage(
+                            input: title,
+                            defaultPlanned: appModel.selection == .planned,
+                            defaultIsImportant: appModel.selection == .important,
+                            defaultIsMyDay: appModel.selection == .myDay,
+                            defaultList: selectedList
+                        )
+                    } catch {
+                    }
                 }
+                .padding(10)
+                .background(tokens.sectionBackground, in: RoundedRectangle(cornerRadius: 12))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(tokens.sectionBorder, lineWidth: 1)
+                }
+                .shadow(color: Color.black.opacity(0.14), radius: 8, y: 3)
             }
-            .padding(10)
-            .background(tokens.sectionBackground, in: RoundedRectangle(cornerRadius: 12))
-            .overlay {
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(tokens.sectionBorder, lineWidth: 1)
-            }
-            .shadow(color: Color.black.opacity(0.14), radius: 8, y: 3)
 
             if isOverdueView && activeTodosCache.isEmpty {
                 Spacer()
@@ -143,13 +158,15 @@ struct TaskListView: View {
                 Spacer()
             } else {
                 HStack(spacing: 12) {
-                    todoColumn(title: "Active", todos: activeTodosCache)
+                    todoColumn(title: isArchiveView ? "Archived" : "Active", todos: activeTodosCache)
                         .frame(maxWidth: .infinity)
 
-                    if isCompletedPanelVisible {
-                        completedColumn(todos: completedTodosCache)
-                            .frame(width: 260)
-                            .transition(.opacity.combined(with: .move(edge: .trailing)))
+                    if !isArchiveView {
+                        if isCompletedPanelVisible {
+                            completedColumn(todos: completedTodosCache)
+                                .frame(width: 260)
+                                .transition(.opacity.combined(with: .move(edge: .trailing)))
+                        }
                     }
                 }
                 .animation(.easeInOut(duration: 0.2), value: isCompletedPanelVisible)
@@ -187,10 +204,18 @@ struct TaskListView: View {
         .alert("Clear completed tasks?", isPresented: $showClearCompletedConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Clear", role: .destructive) {
-                try? store.clearCompletedTodos()
+                try? store.clearCompletedTodos(todoIDs: completedTodosCache.map(\.id))
             }
         } message: {
-            Text("This permanently deletes all completed tasks in the current view.")
+            Text("This moves all completed tasks in the current view to Archive.")
+        }
+        .alert("Empty Archive?", isPresented: $showEmptyArchiveConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Empty", role: .destructive) {
+                try? store.clearArchivedTodos()
+            }
+        } message: {
+            Text("This permanently deletes all archived tasks.")
         }
     }
 
@@ -260,6 +285,8 @@ struct TaskListView: View {
             return "Overdue"
         case .all:
             return "All Tasks"
+        case .archive:
+            return "Archive"
         case let .customList(id):
             return store.lists.first(where: { $0.id == id })?.name ?? "List"
         }
@@ -276,11 +303,15 @@ struct TaskListView: View {
         appModel.selection == .overdue
     }
 
+    private var isArchiveView: Bool {
+        appModel.selection == .archive
+    }
+
     private func recalculateCaches() {
         let filtered = store.filteredVisibleTodos(searchQuery: commandText)
         filteredTodosCache = filtered
-        activeTodosCache = Self.activeTodos(filtered, isOverdueView: isOverdueView)
-        completedTodosCache = filtered.filter(\.isCompleted)
+        activeTodosCache = Self.activeTodos(filtered, isOverdueView: isOverdueView, isArchiveView: isArchiveView)
+        completedTodosCache = isArchiveView ? [] : filtered.filter { $0.isCompleted && !$0.isArchived }
     }
 
     private func rebuildListColorCache() {
@@ -290,8 +321,8 @@ struct TaskListView: View {
         })
     }
 
-    private static func activeTodos(_ todos: [Todo], isOverdueView: Bool) -> [Todo] {
-        var todos = todos.filter { !$0.isCompleted }
+    private static func activeTodos(_ todos: [Todo], isOverdueView: Bool, isArchiveView: Bool) -> [Todo] {
+        var todos = isArchiveView ? todos.filter(\.isArchived) : todos.filter { !$0.isCompleted && !$0.isArchived }
         if isOverdueView {
             todos.sort { ($0.dueDate ?? .distantFuture) < ($1.dueDate ?? .distantFuture) }
         }
@@ -338,6 +369,13 @@ struct TaskListView: View {
                             },
                             onToggleImportant: {
                                 try? store.toggleImportant(todoId: todo.id)
+                            },
+                            onToggleArchive: {
+                                if todo.isArchived {
+                                    try? store.unarchiveTodo(todoId: todo.id)
+                                } else {
+                                    try? store.archiveTodo(todoId: todo.id)
+                                }
                             },
                             onDelete: {
                                 try? store.deleteTodo(todoId: todo.id)
@@ -390,9 +428,9 @@ struct TaskListView: View {
                     Button {
                         showClearCompletedConfirmation = true
                     } label: {
-                        Text("Clear")
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(tokens.accentTerracotta)
+                            Text("Archive")
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(tokens.accentTerracotta)
                     }
                     .buttonStyle(.plain)
                 }
@@ -413,12 +451,19 @@ struct TaskListView: View {
                                 onToggleComplete: {
                                     try? store.toggleComplete(todoId: todo.id)
                                 },
-                                onToggleImportant: {
-                                    try? store.toggleImportant(todoId: todo.id)
-                                },
-                                onDelete: {
-                                    try? store.deleteTodo(todoId: todo.id)
+                            onToggleImportant: {
+                                try? store.toggleImportant(todoId: todo.id)
+                            },
+                            onToggleArchive: {
+                                if todo.isArchived {
+                                    try? store.unarchiveTodo(todoId: todo.id)
+                                } else {
+                                    try? store.archiveTodo(todoId: todo.id)
                                 }
+                            },
+                            onDelete: {
+                                try? store.deleteTodo(todoId: todo.id)
+                            }
                             )
                         }
                     }

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TodoRowView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TodoRowView.swift
@@ -23,6 +23,7 @@ struct TodoRowView: View {
     let onSelect: () -> Void
     let onToggleComplete: () -> Void
     let onToggleImportant: () -> Void
+    let onToggleArchive: () -> Void
     let onDelete: () -> Void
     @Environment(\.themeTokens) private var tokens
     @State private var isHovered: Bool = false
@@ -119,6 +120,17 @@ struct TodoRowView: View {
             }
         }
         .contentShape(Rectangle())
+        .contextMenu {
+            if todo.isArchived {
+                Button("Unarchive", action: onToggleArchive)
+            } else if todo.isCompleted {
+                Button("Archive", action: onToggleArchive)
+            }
+
+            Button(todo.isImportant ? "Mark as not important" : "Mark as important", action: onToggleImportant)
+            Divider()
+            Button("Delete task", role: .destructive, action: onDelete)
+        }
         .onTapGesture {
             onSelect()
         }

--- a/macos/TodoFocusMac/Tests/CoreTests/AppSelectionStateTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/AppSelectionStateTests.swift
@@ -48,6 +48,9 @@ final class AppSelectionStateTests: XCTestCase {
         model.selectSidebar(.all)
         XCTAssertEqual(model.activeViewID, "all")
 
+        model.selectSidebar(.archive)
+        XCTAssertEqual(model.activeViewID, "archive")
+
         model.selectSidebar(.customList("list-1"))
         XCTAssertEqual(model.activeViewID, "list-1")
     }

--- a/macos/TodoFocusMac/Tests/CoreTests/SmartListFilterTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/SmartListFilterTests.swift
@@ -46,6 +46,24 @@ final class SmartListFilterTests: XCTestCase {
         XCTAssertEqual(filterTodos(todos, for: .all).map(\.id), ["a", "b"])
     }
 
+    func testAllSmartListExcludesArchivedTodos() {
+        let todos = [
+            makeTodo(id: "visible"),
+            makeTodo(id: "archived", isArchived: true)
+        ]
+
+        XCTAssertEqual(filterTodos(todos, for: .all).map(\.id), ["visible"])
+    }
+
+    func testArchiveSmartListReturnsOnlyArchivedTodos() {
+        let todos = [
+            makeTodo(id: "visible"),
+            makeTodo(id: "archived", isArchived: true)
+        ]
+
+        XCTAssertEqual(filterTodos(todos, for: .archive).map(\.id), ["archived"])
+    }
+
     func testCustomSmartListMatchesExactListId() {
         let todos = [
             makeTodo(id: "exact", listId: "list-1"),
@@ -115,6 +133,7 @@ final class SmartListFilterTests: XCTestCase {
         isMyDay: Bool = false,
         isImportant: Bool = false,
         isCompleted: Bool = false,
+        isArchived: Bool = false,
         dueDate: Date? = nil,
         listId: String? = nil
     ) -> CoreTodo {
@@ -123,6 +142,7 @@ final class SmartListFilterTests: XCTestCase {
             isMyDay: isMyDay,
             isImportant: isImportant,
             isCompleted: isCompleted,
+            isArchived: isArchived,
             dueDate: dueDate,
             listId: listId
         )

--- a/macos/TodoFocusMac/Tests/CoreTests/TimeFilterTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/TimeFilterTests.swift
@@ -25,22 +25,22 @@ final class TimeFilterTests: XCTestCase {
         let now = date(2026, 3, 21, 23, 59)
         let dueEarlierToday = date(2026, 3, 21, 0, 1)
 
-        XCTAssertFalse(matches(filter: .overdue, dueDate: dueEarlierToday, isCompleted: false, now: now, calendar: calendar))
-        XCTAssertTrue(matches(filter: .today, dueDate: dueEarlierToday, isCompleted: false, now: now, calendar: calendar))
+        XCTAssertFalse(matches(filter: .overdue, dueDate: dueEarlierToday, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+        XCTAssertTrue(matches(filter: .today, dueDate: dueEarlierToday, isCompleted: false, isArchived: false, now: now, calendar: calendar))
     }
 
     func testOverdueMatchesPreviousDay() {
         let now = date(2026, 3, 21, 10)
         let dueYesterday = date(2026, 3, 20, 23, 59)
 
-        XCTAssertTrue(matches(filter: .overdue, dueDate: dueYesterday, isCompleted: false, now: now, calendar: calendar))
+        XCTAssertTrue(matches(filter: .overdue, dueDate: dueYesterday, isCompleted: false, isArchived: false, now: now, calendar: calendar))
     }
 
     func testOverdueExcludesCompletedTasks() {
         let now = date(2026, 3, 21, 10)
         let dueYesterday = date(2026, 3, 20, 23, 59)
 
-        XCTAssertFalse(matches(filter: .overdue, dueDate: dueYesterday, isCompleted: true, now: now, calendar: calendar))
+        XCTAssertFalse(matches(filter: .overdue, dueDate: dueYesterday, isCompleted: true, isArchived: false, now: now, calendar: calendar))
     }
 
     func testTodayMatchesOnlyLocalToday() {
@@ -48,8 +48,8 @@ final class TimeFilterTests: XCTestCase {
         let dueToday = date(2026, 3, 21, 23, 30)
         let dueTomorrow = date(2026, 3, 22, 0, 0)
 
-        XCTAssertTrue(matches(filter: .today, dueDate: dueToday, isCompleted: false, now: now, calendar: calendar))
-        XCTAssertFalse(matches(filter: .today, dueDate: dueTomorrow, isCompleted: false, now: now, calendar: calendar))
+        XCTAssertTrue(matches(filter: .today, dueDate: dueToday, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+        XCTAssertFalse(matches(filter: .today, dueDate: dueTomorrow, isCompleted: false, isArchived: false, now: now, calendar: calendar))
     }
 
     func testTomorrowMatchesNextLocalDayOnly() {
@@ -57,8 +57,8 @@ final class TimeFilterTests: XCTestCase {
         let dueTomorrow = date(2026, 3, 22, 9)
         let dueInTwoDays = date(2026, 3, 23, 9)
 
-        XCTAssertTrue(matches(filter: .tomorrow, dueDate: dueTomorrow, isCompleted: false, now: now, calendar: calendar))
-        XCTAssertFalse(matches(filter: .tomorrow, dueDate: dueInTwoDays, isCompleted: false, now: now, calendar: calendar))
+        XCTAssertTrue(matches(filter: .tomorrow, dueDate: dueTomorrow, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+        XCTAssertFalse(matches(filter: .tomorrow, dueDate: dueInTwoDays, isCompleted: false, isArchived: false, now: now, calendar: calendar))
     }
 
     func testNext7DaysIncludesTodayAndNextSixDays() {
@@ -68,35 +68,42 @@ final class TimeFilterTests: XCTestCase {
         let dueDaySeven = date(2026, 3, 28, 12)
         let dueYesterday = date(2026, 3, 20, 12)
 
-        XCTAssertTrue(matches(filter: .next7Days, dueDate: dueToday, isCompleted: false, now: now, calendar: calendar))
-        XCTAssertTrue(matches(filter: .next7Days, dueDate: dueDaySix, isCompleted: false, now: now, calendar: calendar))
-        XCTAssertFalse(matches(filter: .next7Days, dueDate: dueDaySeven, isCompleted: false, now: now, calendar: calendar))
-        XCTAssertFalse(matches(filter: .next7Days, dueDate: dueYesterday, isCompleted: false, now: now, calendar: calendar))
+        XCTAssertTrue(matches(filter: .next7Days, dueDate: dueToday, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+        XCTAssertTrue(matches(filter: .next7Days, dueDate: dueDaySix, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+        XCTAssertFalse(matches(filter: .next7Days, dueDate: dueDaySeven, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+        XCTAssertFalse(matches(filter: .next7Days, dueDate: dueYesterday, isCompleted: false, isArchived: false, now: now, calendar: calendar))
     }
 
     func testNoDateMatchesOnlyNilDueDate() {
         let now = date(2026, 3, 21, 10)
         let dueToday = date(2026, 3, 21, 18)
 
-        XCTAssertTrue(matches(filter: .noDate, dueDate: nil, isCompleted: false, now: now, calendar: calendar))
-        XCTAssertFalse(matches(filter: .noDate, dueDate: dueToday, isCompleted: false, now: now, calendar: calendar))
+        XCTAssertTrue(matches(filter: .noDate, dueDate: nil, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+        XCTAssertFalse(matches(filter: .noDate, dueDate: dueToday, isCompleted: false, isArchived: false, now: now, calendar: calendar))
     }
 
     func testAllDatesAlwaysMatches() {
         let now = date(2026, 3, 21, 10)
         let dueToday = date(2026, 3, 21, 18)
 
-        XCTAssertTrue(matches(filter: .allDates, dueDate: nil, isCompleted: false, now: now, calendar: calendar))
-        XCTAssertTrue(matches(filter: .allDates, dueDate: dueToday, isCompleted: false, now: now, calendar: calendar))
+        XCTAssertTrue(matches(filter: .allDates, dueDate: nil, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+        XCTAssertTrue(matches(filter: .allDates, dueDate: dueToday, isCompleted: false, isArchived: false, now: now, calendar: calendar))
     }
 
     func testNonAllDateFiltersRejectNilDueDate() {
         let now = date(2026, 3, 21, 10)
 
-        XCTAssertFalse(matches(filter: .overdue, dueDate: nil, isCompleted: false, now: now, calendar: calendar))
-        XCTAssertFalse(matches(filter: .today, dueDate: nil, isCompleted: false, now: now, calendar: calendar))
-        XCTAssertFalse(matches(filter: .tomorrow, dueDate: nil, isCompleted: false, now: now, calendar: calendar))
-        XCTAssertFalse(matches(filter: .next7Days, dueDate: nil, isCompleted: false, now: now, calendar: calendar))
+        XCTAssertFalse(matches(filter: .overdue, dueDate: nil, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+        XCTAssertFalse(matches(filter: .today, dueDate: nil, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+        XCTAssertFalse(matches(filter: .tomorrow, dueDate: nil, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+        XCTAssertFalse(matches(filter: .next7Days, dueDate: nil, isCompleted: false, isArchived: false, now: now, calendar: calendar))
+    }
+
+    func testOverdueExcludesArchivedTasks() {
+        let now = date(2026, 3, 21, 10)
+        let dueYesterday = date(2026, 3, 20, 23, 59)
+
+        XCTAssertFalse(matches(filter: .overdue, dueDate: dueYesterday, isCompleted: true, isArchived: true, now: now, calendar: calendar))
     }
 
     func testTodoIsOverdueExcludesDatesEarlierToday() {

--- a/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/TodoAppStoreTests.swift
@@ -388,7 +388,7 @@ final class TodoAppStoreTests: XCTestCase {
         XCTAssertFalse(store.todos.contains(where: { $0.id == created.id }))
     }
 
-    func testClearCompletedTodosRemovesCompletedAndClearsSelectionForCompletedSelection() throws {
+    func testClearCompletedTodosArchivesCompletedAndClearsSelectionForCompletedSelection() throws {
         let (store, _, _, _) = try makeStore()
         let active = try store.quickAdd(
             title: "Active",
@@ -412,7 +412,123 @@ final class TodoAppStoreTests: XCTestCase {
 
         XCTAssertNil(store.selectedTodo)
         XCTAssertTrue(store.todos.contains(where: { $0.id == active.id }))
-        XCTAssertFalse(store.todos.contains(where: { $0.id == completed.id }))
+        XCTAssertTrue(store.todos.contains(where: { $0.id == completed.id && $0.isArchived }))
+        XCTAssertFalse(store.visibleTodos.contains(where: { $0.id == completed.id }))
+    }
+
+    func testVisibleTodosExcludesArchivedItemsFromRegularViews() throws {
+        let (store, appModel, _, todoRepository) = try makeStore()
+        let archived = try store.quickAdd(
+            title: "Archived done",
+            planned: false,
+            isImportant: true,
+            isMyDay: false,
+            list: nil
+        )
+        let visible = try store.quickAdd(
+            title: "Visible done",
+            planned: false,
+            isImportant: true,
+            isMyDay: false,
+            list: nil
+        )
+
+        try store.toggleComplete(todoId: archived.id)
+        try store.toggleComplete(todoId: visible.id)
+
+        var archivePatch = UpdateTodoInput()
+        archivePatch.isArchived = true
+        try todoRepository.updateTodo(id: archived.id, input: archivePatch)
+        try store.reload()
+        appModel.selection = .all
+
+        XCTAssertEqual(store.visibleTodos.map(\.id), [visible.id])
+        XCTAssertEqual(store.todoCount, 1)
+        XCTAssertEqual(store.archivedCount, 1)
+    }
+
+    func testArchiveSelectionShowsArchivedItems() throws {
+        let (store, appModel, _, todoRepository) = try makeStore()
+        let archived = try store.quickAdd(
+            title: "Archived done",
+            planned: false,
+            isImportant: false,
+            isMyDay: false,
+            list: nil
+        )
+
+        try store.toggleComplete(todoId: archived.id)
+        var archivePatch = UpdateTodoInput()
+        archivePatch.isArchived = true
+        try todoRepository.updateTodo(id: archived.id, input: archivePatch)
+        try store.reload()
+        appModel.selection = .archive
+
+        XCTAssertEqual(store.visibleTodos.map(\.id), [archived.id])
+    }
+
+    func testClearArchivedTodosRemovesArchivedRowsAndClearsSelection() throws {
+        let (store, appModel, _, todoRepository) = try makeStore()
+        let archived = try store.quickAdd(
+            title: "Archived done",
+            planned: false,
+            isImportant: false,
+            isMyDay: false,
+            list: nil
+        )
+        let visible = try store.quickAdd(
+            title: "Visible active",
+            planned: false,
+            isImportant: false,
+            isMyDay: false,
+            list: nil
+        )
+
+        try store.toggleComplete(todoId: archived.id)
+        var archivePatch = UpdateTodoInput()
+        archivePatch.isArchived = true
+        try todoRepository.updateTodo(id: archived.id, input: archivePatch)
+        try store.reload()
+        appModel.selection = .archive
+        store.selectTodo(todoId: archived.id)
+
+        try store.clearArchivedTodos()
+
+        XCTAssertNil(store.selectedTodo)
+        XCTAssertFalse(store.todos.contains(where: { $0.id == archived.id }))
+        XCTAssertTrue(store.todos.contains(where: { $0.id == visible.id }))
+        XCTAssertEqual(store.archivedCount, 0)
+    }
+
+    func testClearCompletedTodosWithExplicitIDsArchivesOnlyMatchingCompletedRows() throws {
+        let (store, _, _, _) = try makeStore()
+        let first = try store.quickAdd(title: "First", planned: false, isImportant: false, isMyDay: false, list: nil)
+        let second = try store.quickAdd(title: "Second", planned: false, isImportant: false, isMyDay: false, list: nil)
+
+        try store.toggleComplete(todoId: first.id)
+        try store.toggleComplete(todoId: second.id)
+
+        try store.clearCompletedTodos(todoIDs: [first.id])
+
+        XCTAssertTrue(store.todos.contains(where: { $0.id == first.id && $0.isArchived }))
+        XCTAssertTrue(store.todos.contains(where: { $0.id == second.id && !$0.isArchived }))
+    }
+
+    func testUnarchiveTodoClearsSelection() throws {
+        let (store, _, _, todoRepository) = try makeStore()
+        let archived = try store.quickAdd(title: "Archived done", planned: false, isImportant: false, isMyDay: false, list: nil)
+
+        try store.toggleComplete(todoId: archived.id)
+        var archivePatch = UpdateTodoInput()
+        archivePatch.isArchived = true
+        try todoRepository.updateTodo(id: archived.id, input: archivePatch)
+        try store.reload()
+        store.selectTodo(todoId: archived.id)
+
+        try store.unarchiveTodo(todoId: archived.id)
+
+        XCTAssertNil(store.selectedTodo)
+        XCTAssertTrue(store.todos.contains(where: { $0.id == archived.id && !$0.isArchived }))
     }
 
     @MainActor

--- a/macos/TodoFocusMac/Tests/CoreTests/TodoQueryTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/TodoQueryTests.swift
@@ -36,11 +36,36 @@ final class TodoQueryTests: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
+    func testQueryExcludesArchivedTodosFromRegularViews() {
+        let todos = [
+            makeTodo(id: "visible", isImportant: true, dueDate: now),
+            makeTodo(id: "archived", isImportant: true, isArchived: true, dueDate: now)
+        ]
+
+        let query = TodoQuery(smartList: .important, timeFilter: .today)
+        let result = query.apply(todos, now: now, calendar: utcCalendar)
+
+        XCTAssertEqual(result.map(\.id), ["visible"])
+    }
+
+    func testQueryArchiveViewIncludesArchivedTodos() {
+        let todos = [
+            makeTodo(id: "visible", isCompleted: true, dueDate: now),
+            makeTodo(id: "archived", isCompleted: true, isArchived: true, dueDate: now)
+        ]
+
+        let query = TodoQuery(smartList: .archive, timeFilter: .allDates)
+        let result = query.apply(todos, now: now, calendar: utcCalendar)
+
+        XCTAssertEqual(result.map(\.id), ["archived"])
+    }
+
     private func makeTodo(
         id: String,
         isMyDay: Bool = false,
         isImportant: Bool = false,
         isCompleted: Bool = false,
+        isArchived: Bool = false,
         dueDate: Date? = nil,
         listId: String? = nil
     ) -> CoreTodo {
@@ -49,6 +74,7 @@ final class TodoQueryTests: XCTestCase {
             isMyDay: isMyDay,
             isImportant: isImportant,
             isCompleted: isCompleted,
+            isArchived: isArchived,
             dueDate: dueDate,
             listId: listId
         )

--- a/macos/TodoFocusMac/Tests/DataTests/ExportServiceTests.swift
+++ b/macos/TodoFocusMac/Tests/DataTests/ExportServiceTests.swift
@@ -54,6 +54,7 @@ final class ExportServiceTests: XCTestCase {
                 id: "todo-1",
                 title: "Ship",
                 isCompleted: false,
+                isArchived: false,
                 isImportant: true,
                 isMyDay: true,
                 recurrence: nil,
@@ -156,6 +157,38 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertEqual(todo.launchResources.count, 1)
         XCTAssertEqual(todo.launchResources.first?.type, LaunchResourceType.url.rawValue)
         XCTAssertEqual(todo.launchResources.first?.value, "https://example.com")
+        XCTAssertFalse(todo.isArchived)
+    }
+
+    func testDecodeLegacyTodoDefaultsMissingArchiveFlagToFalse() throws {
+        let payload = """
+        {
+          "version": "1.3",
+          "exportedAt": "2026-03-28T12:00:00Z",
+          "lists": [],
+          "todos": [
+            {
+              "id": "todo-legacy",
+              "title": "Legacy Todo",
+              "isCompleted": true,
+              "isImportant": false,
+              "isMyDay": false,
+              "dueDate": null,
+              "notes": "",
+              "listId": null,
+              "focusTimeSeconds": 0,
+              "recurrence": null,
+              "recurrenceInterval": 1,
+              "sortOrder": 0,
+              "steps": [],
+              "launchResources": []
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try ExportData.decode(from: payload)
+        XCTAssertFalse(try XCTUnwrap(decoded.todos.first).isArchived)
     }
 
     func testPreflightWarnsWhenNonPortableLaunchResourcesExist() throws {
@@ -331,6 +364,7 @@ final class ExportServiceTests: XCTestCase {
                 id: todo.id,
                 title: todo.title,
                 isCompleted: todo.isCompleted,
+                isArchived: todo.isArchived,
                 isImportant: todo.isImportant,
                 isMyDay: todo.isMyDay,
                 dueDate: todo.dueDate,
@@ -394,6 +428,7 @@ final class ExportServiceTests: XCTestCase {
                     id: "todo-1",
                     title: "Imported",
                     isCompleted: true,
+                    isArchived: false,
                     isImportant: false,
                     isMyDay: false,
                     dueDate: nil,
@@ -418,6 +453,46 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertEqual(todo.createdAt, createdAt)
         XCTAssertEqual(todo.updatedAt, updatedAt)
         XCTAssertEqual(todo.lastCompletedAt, lastCompletedAt)
+    }
+
+    func testReplaceImportNormalizesArchivedTodoToCompleted() throws {
+        let manager = try makeManager()
+        let service = makeService(manager)
+
+        let payload = ExportData(
+            version: ExportFormatVersion.current,
+            exportedAt: Date(),
+            meta: nil,
+            lists: [],
+            todos: [
+                ExportTodo(
+                    id: "todo-1",
+                    title: "Imported",
+                    isCompleted: false,
+                    isArchived: true,
+                    isImportant: false,
+                    isMyDay: false,
+                    dueDate: nil,
+                    notes: "",
+                    listId: nil,
+                    focusTimeSeconds: 0,
+                    recurrence: nil,
+                    recurrenceInterval: 1,
+                    sortOrder: 0,
+                    createdAt: nil,
+                    updatedAt: nil,
+                    lastCompletedAt: nil,
+                    steps: [],
+                    launchResources: []
+                )
+            ]
+        )
+
+        _ = try service.executeImportJSON(try payload.encode(), mode: .replace)
+        let todo = try XCTUnwrap(TodoRepository(dbQueue: manager.dbQueue).fetchTodo(id: "todo-1"))
+
+        XCTAssertTrue(todo.isArchived)
+        XCTAssertTrue(todo.isCompleted)
     }
 
     func testPreflightRejectsTodoListReferenceMissingInReplaceMode() throws {
@@ -503,6 +578,7 @@ final class ExportServiceTests: XCTestCase {
                     id: "todo-import",
                     title: "Imported",
                     isCompleted: false,
+                    isArchived: false,
                     isImportant: false,
                     isMyDay: false,
                     dueDate: nil,

--- a/macos/TodoFocusMac/Tests/DataTests/TodoRepositoryTests.swift
+++ b/macos/TodoFocusMac/Tests/DataTests/TodoRepositoryTests.swift
@@ -2,9 +2,13 @@ import XCTest
 @testable import TodoFocusMac
 
 final class TodoRepositoryTests: XCTestCase {
-    private func makeRepository() throws -> TodoRepository {
+    private func makeDatabaseManager() throws -> DatabaseManager {
         let path = NSTemporaryDirectory() + UUID().uuidString + ".sqlite"
-        let manager = try DatabaseManager(databasePath: path)
+        return try DatabaseManager(databasePath: path)
+    }
+
+    private func makeRepository() throws -> TodoRepository {
+        let manager = try makeDatabaseManager()
         return TodoRepository(dbQueue: manager.dbQueue)
     }
 
@@ -252,5 +256,53 @@ final class TodoRepositoryTests: XCTestCase {
         XCTAssertEqual(deletedCount, 1)
         XCTAssertNotNil(try repo.fetchTodo(id: active.id))
         XCTAssertNil(try repo.fetchTodo(id: completed.id))
+    }
+
+    func testClearCompletedTodosPreservesArchivedCompletedRows() throws {
+        let manager = try makeDatabaseManager()
+        let repo = TodoRepository(dbQueue: manager.dbQueue)
+        let archivedCompleted = try repo.addTodo(
+            AddTodoInput(title: "Archived done", listID: nil, isMyDay: false, isImportant: false, planned: false)
+        )
+        let plainCompleted = try repo.addTodo(
+            AddTodoInput(title: "Plain done", listID: nil, isMyDay: false, isImportant: false, planned: false)
+        )
+
+        var completedPatch = UpdateTodoInput()
+        completedPatch.isCompleted = true
+        try repo.updateTodo(id: archivedCompleted.id, input: completedPatch)
+        try repo.updateTodo(id: plainCompleted.id, input: completedPatch)
+
+        try manager.dbQueue.write { db in
+            try db.execute(sql: "UPDATE todo SET isArchived = 1 WHERE id = ?", arguments: [archivedCompleted.id])
+        }
+
+        let deletedCount = try repo.clearCompletedTodos()
+
+        XCTAssertEqual(deletedCount, 1)
+        XCTAssertNotNil(try repo.fetchTodo(id: archivedCompleted.id))
+        XCTAssertNil(try repo.fetchTodo(id: plainCompleted.id))
+    }
+
+    func testClearArchivedTodosDeletesOnlyArchivedRows() throws {
+        let manager = try makeDatabaseManager()
+        let repo = TodoRepository(dbQueue: manager.dbQueue)
+        let archived = try repo.addTodo(
+            AddTodoInput(title: "Archived", listID: nil, isMyDay: false, isImportant: false, planned: false)
+        )
+        let visible = try repo.addTodo(
+            AddTodoInput(title: "Visible", listID: nil, isMyDay: false, isImportant: false, planned: false)
+        )
+
+        var archivePatch = UpdateTodoInput()
+        archivePatch.isCompleted = true
+        archivePatch.isArchived = true
+        try repo.updateTodo(id: archived.id, input: archivePatch)
+
+        let deletedCount = try repo.clearArchivedTodos()
+
+        XCTAssertEqual(deletedCount, 1)
+        XCTAssertNil(try repo.fetchTodo(id: archived.id))
+        XCTAssertNotNil(try repo.fetchTodo(id: visible.id))
     }
 }


### PR DESCRIPTION
## Summary
- add completed-task archiving with a dedicated Archive sidebar view and right-click archive/unarchive actions
- change Clear completed to move only the currently visible completed tasks into Archive, and add an Empty Archive action for permanent deletion
- persist archive state through storage and export/import, with safeguards and regression coverage for archive visibility, selection cleanup, and deletion behavior

## Verification
- xcodebuild build -project \"macos/TodoFocusMac/TodoFocusMac.xcodeproj\" -scheme \"TodoFocusMac\" -destination \"platform=macOS\"
- xcodebuild test -project \"macos/TodoFocusMac/TodoFocusMac.xcodeproj\" -scheme \"TodoFocusMac\" -destination \"platform=macOS\" -only-testing:\"DataTests/TodoRepositoryTests\" -only-testing:\"DataTests/ExportServiceTests\" -only-testing:\"CoreTests/TimeFilterTests\" -only-testing:\"CoreTests/SmartListFilterTests\" -only-testing:\"CoreTests/TodoQueryTests\" -only-testing:\"CoreTests/TodoAppStoreTests\" -only-testing:\"CoreTests/AppSelectionStateTests\" -only-testing:\"CoreTests/DailyReviewViewTests\"
- xcodebuild test -project \"macos/TodoFocusMac/TodoFocusMac.xcodeproj\" -scheme \"TodoFocusMac\" -destination \"platform=macOS\" -only-testing:\"CoreTests/TodoAppStoreTests/testClearArchivedTodosRemovesArchivedRowsAndClearsSelection\" -only-testing:\"CoreTests/TodoAppStoreTests/testClearCompletedTodosWithExplicitIDsArchivesOnlyMatchingCompletedRows\" -only-testing:\"CoreTests/TodoAppStoreTests/testUnarchiveTodoClearsSelection\" -only-testing:\"DataTests/TodoRepositoryTests/testClearArchivedTodosDeletesOnlyArchivedRows\" -only-testing:\"DataTests/ExportServiceTests/testReplaceImportNormalizesArchivedTodoToCompleted\"