### PR TITLE
Polish Daily Review preview and archive action UI

### DIFF
--- a/macos/TodoFocusMac/Sources/Features/Common/ShortcutHintBar.swift
+++ b/macos/TodoFocusMac/Sources/Features/Common/ShortcutHintBar.swift
@@ -14,11 +14,11 @@ struct ShortcutHintBar: View {
             Spacer()
 
             HStack(spacing: 12) {
-                shortcutPill("⌘⇧T", "Quick Capture")
-                shortcutPill("⌘⇧F", "Focus")
-                shortcutPill("⌘K", "Search")
-                shortcutPill("⌘⇧L", "Theme")
-                shortcutPill("⌘⇧N", "Add")
+                shortcutPill("⌘⇧T", "Global Quick Capture")
+                shortcutPill("⌘⇧F", "Start Deep Focus")
+                shortcutPill("⌘K", "Search Tasks")
+                shortcutPill("⌘⇧L", "Toggle Theme")
+                shortcutPill("⌘⇧N", "New Task")
             }
         }
         .padding(.horizontal, 12)

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewPreviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewPreviewView.swift
@@ -102,12 +102,27 @@ struct DailyReviewPreviewView: View {
                 .accessibilityLabel("Close preview")
             }
 
-            HStack(spacing: 8) {
-                metricPill(title: "Open", value: totalOpen)
-                metricPill(title: "Today", value: todayOpen)
-                metricPill(title: "Overdue", value: overdueOpen)
-                if totalCompleted > 0 {
-                    metricPill(title: "Done", value: totalCompleted)
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) {
+                    metricPill(title: "Open", value: totalOpen)
+                    metricPill(title: "Today", value: todayOpen)
+                    metricPill(title: "Overdue", value: overdueOpen)
+                    if totalCompleted > 0 {
+                        metricPill(title: "Done", value: totalCompleted)
+                    }
+                }
+                
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        metricPill(title: "Open", value: totalOpen)
+                        metricPill(title: "Today", value: todayOpen)
+                    }
+                    HStack(spacing: 8) {
+                        metricPill(title: "Overdue", value: overdueOpen)
+                        if totalCompleted > 0 {
+                            metricPill(title: "Done", value: totalCompleted)
+                        }
+                    }
                 }
             }
         }
@@ -154,7 +169,6 @@ struct DailyReviewPreviewView: View {
                     .font(.subheadline.weight(isCompletedSection ? .medium : .semibold))
                     .foregroundStyle(isCompletedSection ? tokens.textSecondary : tokens.textPrimary)
                     .strikethrough(isCompletedSection)
-                    .lineLimit(1)
 
                 HStack(spacing: 6) {
                     dueChip(text: DailyReview.dueText(for: task.dueDate), bucket: DailyReview.dueBucket(for: task.dueDate))
@@ -179,20 +193,21 @@ struct DailyReviewPreviewView: View {
     }
 
     private func metricPill(title: String, value: Int) -> some View {
-        HStack(spacing: 7) {
+        HStack(spacing: 6) {
             Text(title)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(tokens.textSecondary)
+                .lineLimit(1)
             Text("\(value)")
                 .font(.caption.weight(.bold))
                 .monospacedDigit()
                 .foregroundStyle(tokens.textPrimary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
                 .background(tokens.bgFloating.opacity(0.9), in: Capsule())
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
         .background(tokens.sectionBackground, in: Capsule())
         .overlay {
             Capsule()

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
@@ -73,9 +73,20 @@ struct TaskListView: View {
                     Button(role: .destructive) {
                         showEmptyArchiveConfirmation = true
                     } label: {
-                        Text("Empty Archive")
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(tokens.danger)
+                        HStack(spacing: 6) {
+                            Image(systemName: "trash")
+                                .font(.system(size: 11, weight: .semibold))
+                            Text("Empty Archive")
+                                .font(.caption.weight(.semibold))
+                        }
+                        .foregroundStyle(filteredTodosCache.isEmpty ? tokens.textTertiary : tokens.danger)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(tokens.bgFloating.opacity(0.82), in: Capsule())
+                        .overlay {
+                            Capsule()
+                                .stroke(filteredTodosCache.isEmpty ? tokens.sectionBorder.opacity(0.5) : tokens.danger.opacity(0.4), lineWidth: 1)
+                        }
                     }
                     .buttonStyle(.plain)
                     .disabled(filteredTodosCache.isEmpty)


### PR DESCRIPTION
## Summary
- improve the compact Daily Review preview stats layout so the metric pills stay readable in the floating panel
- make the shortcut hint bar labels more explicit without changing any key bindings
- restyle the Archive view's Empty Archive action to match the app's existing capsule controls while keeping destructive behavior

## Verification
- xcodegen generate
- xcodebuild test -project \"TodoFocusMac.xcodeproj\" -scheme \"TodoFocusMac\" -destination \"platform=macOS\"
- xcodebuild build -project \"TodoFocusMac.xcodeproj\" -scheme \"TodoFocusMac\" -configuration Release -derivedDataPath \"build/DerivedData\" -destination \"platform=macOS\"
- smoke check: launched the built Release app successfully in this environment

## Notes
- left the unrelated untracked plan file in docs/superpowers/plans/ untouched
- SourceKit directory diagnostics are noisy/pre-existing for this repo setup, so build and test outputs were used as the authoritative verification