### PR TITLE
feat(macOS): show shortcut hints and fix preview activation

### DIFF
--- a/docs/superpowers/issues/2026-04-28-shortcut-hints-preview-activation.md
+++ b/docs/superpowers/issues/2026-04-28-shortcut-hints-preview-activation.md
@@ -1,0 +1,16 @@
+# Shortcut Hints and Preview Activation
+
+## Problem
+
+The app should show all available keyboard shortcuts in a persistent bottom-right hint bar. The current hint bar is attached to `TaskListView`, so it is not global, and it omits the Daily Review Preview shortcut `⌘⇧U`.
+
+The Daily Review Preview panel opens with `⌘⇧U`, but pressing its “Open Daily Review” button does not reliably trigger the main app from the floating preview panel.
+
+## Success Criteria
+
+- The shortcut hint bar appears at the app root in the bottom-right corner.
+- The hint bar includes `⌘⇧T`, `⌘⇧U`, `⌘⇧F`, `⌘K`, `⌘⇧L`, and `⌘⇧N`.
+- The Task List no longer owns the hint bar.
+- The Daily Review Preview activation action hides the preview, activates the current app, and posts the Daily Review navigation notification.
+- Regression tests cover the shortcut list and preview activation sequence where practical.
+

--- a/docs/superpowers/plans/2026-04-28-shortcut-hints-preview-activation.md
+++ b/docs/superpowers/plans/2026-04-28-shortcut-hints-preview-activation.md
@@ -1,0 +1,58 @@
+# Shortcut Hints and Preview Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show all app shortcuts in a global bottom-right hint bar and fix Daily Review Preview activation from the floating panel.
+
+**Architecture:** Keep UI changes small by reusing `ShortcutHintBar` and moving its attachment point from `TaskListView` to `RootView`. Make Daily Review Preview activation testable by routing the button through a service method with injectable activation and notification dependencies.
+
+**Tech Stack:** SwiftUI, AppKit `NSRunningApplication`, XCTest, Observation.
+
+---
+
+## Chunk 1: Tests First
+
+### Task 1: Shortcut and Activation Regression Tests
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Tests/CoreTests/FeatureBehaviorTests.swift`
+
+- [ ] Add a test asserting `ShortcutHintBar.availableShortcuts` exposes every user-visible shortcut, including `⌘⇧U`.
+- [ ] Add a test for `DailyReviewPreviewService.activateAppAndNavigateToDailyReview()` that verifies the service hides the panel state, calls the app activator, and posts `.todoFocusNavigateToDailyReview`.
+- [ ] Run the focused test target and confirm the new tests fail before implementation.
+
+## Chunk 2: Implementation
+
+### Task 2: Global Shortcut Hint Bar
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Sources/Features/Common/ShortcutHintBar.swift`
+- Modify: `macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift`
+- Modify: `macos/TodoFocusMac/Sources/RootView.swift`
+
+- [ ] Add a small `ShortcutHintItem` model and a static `availableShortcuts` list to `ShortcutHintBar`.
+- [ ] Render shortcut pills from the static list and include `⌘⇧U`.
+- [ ] Remove `.shortcutHintBar(...)` from `TaskListView`.
+- [ ] Add `ShortcutHintBar` as a `RootView` bottom-trailing overlay with padding so it stays in the app chrome globally.
+
+### Task 3: Daily Review Preview Activation
+
+**Files:**
+- Modify: `macos/TodoFocusMac/Sources/Features/Review/DailyReviewPreviewService.swift`
+- Modify: `macos/TodoFocusMac/Sources/RootView.swift`
+
+- [ ] Add `.todoFocusNavigateToDailyReview` as a typed notification name.
+- [ ] Add injectable `appActivator` and `notificationCenter` dependencies to `DailyReviewPreviewService`.
+- [ ] Route the preview button closure through `activateAppAndNavigateToDailyReview()`.
+- [ ] Use `NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])` for the default app activator, then bring the main window forward where possible.
+- [ ] Update `RootView` to receive the typed notification.
+
+## Chunk 3: Verification and PR Artifact
+
+- [ ] Run focused tests for the changed behavior.
+- [ ] Run `xcodegen generate` if the project file needs regeneration.
+- [ ] Run the required full test command.
+- [ ] Run the required Release build command.
+- [ ] Write `docs/superpowers/prs/2026-04-28-shortcut-hints-preview-activation.md`.
+- [ ] Commit, push, and open a PR.
+

--- a/docs/superpowers/prs/2026-04-28-shortcut-hints-preview-activation.md
+++ b/docs/superpowers/prs/2026-04-28-shortcut-hints-preview-activation.md
@@ -1,0 +1,29 @@
+# Show Global Shortcut Hints and Fix Preview Activation
+
+Closes #183
+
+## Summary
+
+- Moves the shortcut hint bar to `RootView` as a global bottom-right overlay.
+- Adds `⌘⇧U` / Daily Review Preview to the visible shortcut list.
+- Routes Daily Review Preview activation through `DailyReviewPreviewService.activateAppAndNavigateToDailyReview()`.
+- Uses `NSRunningApplication.current.activate(options: [.activateAllWindows])`, `NSApp.activate(ignoringOtherApps: true)`, and a visible non-preview window focus step before posting the Daily Review navigation notification.
+- Adds regression coverage for shortcut list contents and preview activation sequencing.
+
+## Verification
+
+- `xcodegen generate`
+  - Created project at `macos/TodoFocusMac/TodoFocusMac.xcodeproj`
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:CoreTests/FeatureBehaviorTests`
+  - `** TEST SUCCEEDED **`
+- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
+  - `** TEST SUCCEEDED **`
+  - CoreTests: 120 tests, 0 failures
+  - DataTests: 53 tests, 0 failures
+- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
+  - `** BUILD SUCCEEDED **`
+
+## Notes
+
+- Release build still emits the existing widget extension `CFBundleVersion` warning.
+

--- a/macos/TodoFocusMac/Sources/Features/Common/ShortcutHintBar.swift
+++ b/macos/TodoFocusMac/Sources/Features/Common/ShortcutHintBar.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 
+struct ShortcutHintItem: Identifiable, Equatable {
+    let key: String
+    let action: String
+
+    var id: String { key }
+}
+
 struct ShortcutHintBar: View {
+    static let availableShortcuts: [ShortcutHintItem] = [
+        ShortcutHintItem(key: "⌘⇧T", action: "Global Quick Capture"),
+        ShortcutHintItem(key: "⌘⇧U", action: "Daily Review Preview"),
+        ShortcutHintItem(key: "⌘⇧F", action: "Start Deep Focus"),
+        ShortcutHintItem(key: "⌘K", action: "Search Tasks"),
+        ShortcutHintItem(key: "⌘⇧L", action: "Toggle Theme"),
+        ShortcutHintItem(key: "⌘⇧N", action: "New Task")
+    ]
+
     var needsAccessibilityPermission: Bool = false
     var onRequestPermission: (() -> Void)?
     @Environment(\.themeTokens) private var tokens
@@ -14,11 +30,9 @@ struct ShortcutHintBar: View {
             Spacer()
 
             HStack(spacing: 12) {
-                shortcutPill("⌘⇧T", "Global Quick Capture")
-                shortcutPill("⌘⇧F", "Start Deep Focus")
-                shortcutPill("⌘K", "Search Tasks")
-                shortcutPill("⌘⇧L", "Toggle Theme")
-                shortcutPill("⌘⇧N", "New Task")
+                ForEach(Self.availableShortcuts) { shortcut in
+                    shortcutPill(shortcut.key, shortcut.action)
+                }
             }
         }
         .padding(.horizontal, 12)

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewPreviewService.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewPreviewService.swift
@@ -2,14 +2,28 @@ import AppKit
 import Observation
 import SwiftUI
 
+extension Notification.Name {
+    static let todoFocusNavigateToDailyReview = Notification.Name("todoFocusNavigateToDailyReview")
+}
+
 @Observable
 @MainActor
 final class DailyReviewPreviewService {
     var isVisible: Bool = false
     private var panel: DailyReviewPreviewPanel?
     private var hostingView: DailyReviewPreviewHostingView?
+    @ObservationIgnored private let appActivator: @MainActor () -> Void
+    @ObservationIgnored private let notificationCenter: NotificationCenter
     
     var store: TodoAppStore?
+
+    init(
+        appActivator: @escaping @MainActor () -> Void = DailyReviewPreviewService.activateCurrentApplication,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.appActivator = appActivator
+        self.notificationCenter = notificationCenter
+    }
     
     func showPanel() {
         guard let store else { return }
@@ -25,9 +39,7 @@ final class DailyReviewPreviewService {
             self?.hidePanel()
         }
         let onActivateApp: () -> Void = { [weak self] in
-            self?.hidePanel()
-            NSApp.activate(ignoringOtherApps: true)
-            NotificationCenter.default.post(name: Notification.Name("todoFocusNavigateToDailyReview"), object: nil)
+            self?.activateAppAndNavigateToDailyReview()
         }
         
         if hostingView == nil {
@@ -62,5 +74,19 @@ final class DailyReviewPreviewService {
         } else {
             showPanel()
         }
+    }
+
+    func activateAppAndNavigateToDailyReview() {
+        hidePanel()
+        appActivator()
+        notificationCenter.post(name: .todoFocusNavigateToDailyReview, object: nil)
+    }
+
+    private static func activateCurrentApplication() {
+        NSRunningApplication.current.activate(options: [.activateAllWindows])
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.windows
+            .first { $0.isVisible && $0.canBecomeKey && !($0 is DailyReviewPreviewPanel) }?
+            .makeKeyAndOrderFront(nil)
     }
 }

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
@@ -183,12 +183,6 @@ struct TaskListView: View {
                 .animation(.easeInOut(duration: 0.2), value: isCompletedPanelVisible)
             }
         }
-        .shortcutHintBar(
-            needsAccessibilityPermission: appModel.quickCaptureService.needsAccessibilityPermission,
-            onRequestPermission: {
-                appModel.quickCaptureService.requestAccessibilityPermission()
-            }
-        )
         .padding(16)
         .foregroundStyle(.primary)
         .animation(MotionTokens.interactiveSpring, value: filteredTodosCache.count)

--- a/macos/TodoFocusMac/Sources/RootView.swift
+++ b/macos/TodoFocusMac/Sources/RootView.swift
@@ -142,20 +142,31 @@ struct RootView: View {
             }
             isHardFocusActive = isEnforcing
         }
-        .onReceive(NotificationCenter.default.publisher(for: Notification.Name("todoFocusNavigateToDailyReview"))) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: .todoFocusNavigateToDailyReview)) { _ in
             appModel.selectSidebar(.dailyReview)
         }
         .immersiveHeader(isExpanded: $isHeaderExpanded, isSidebarVisible: $isSidebarVisible)
         .environment(\.themeTokens, themeTokens)
         .overlay(alignment: .bottomTrailing) {
-            Button("") {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    themeStore.cycleTheme()
+            ZStack(alignment: .bottomTrailing) {
+                ShortcutHintBar(
+                    needsAccessibilityPermission: appModel.quickCaptureService.needsAccessibilityPermission,
+                    onRequestPermission: {
+                        appModel.quickCaptureService.requestAccessibilityPermission()
+                    }
+                )
+                .padding(.trailing, 16)
+                .padding(.bottom, 16)
+
+                Button("") {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        themeStore.cycleTheme()
+                    }
                 }
+                .keyboardShortcut("l", modifiers: [.command, .shift])
+                .opacity(0)
+                .allowsHitTesting(false)
             }
-            .keyboardShortcut("l", modifiers: [.command, .shift])
-            .opacity(0)
-            .allowsHitTesting(false)
         }
         .safeAreaInset(edge: .top) {
             if isHardFocusActive {

--- a/macos/TodoFocusMac/Tests/CoreTests/FeatureBehaviorTests.swift
+++ b/macos/TodoFocusMac/Tests/CoreTests/FeatureBehaviorTests.swift
@@ -29,6 +29,48 @@ final class FeatureBehaviorTests: XCTestCase {
         XCTAssertEqual(text, "Launched 2. 1 failed")
     }
 
+    func testShortcutHintBarListsAllAvailableShortcuts() {
+        XCTAssertEqual(ShortcutHintBar.availableShortcuts.map(\.key), ["⌘⇧T", "⌘⇧U", "⌘⇧F", "⌘K", "⌘⇧L", "⌘⇧N"])
+        XCTAssertEqual(ShortcutHintBar.availableShortcuts.map(\.action), [
+            "Global Quick Capture",
+            "Daily Review Preview",
+            "Start Deep Focus",
+            "Search Tasks",
+            "Toggle Theme",
+            "New Task"
+        ])
+    }
+
+    func testDailyReviewPreviewActivationHidesPreviewActivatesAppAndPostsNavigation() {
+        let notificationCenter = NotificationCenter()
+        var didActivateApp = false
+        var didReceiveNavigation = false
+        let observer = notificationCenter.addObserver(
+            forName: .todoFocusNavigateToDailyReview,
+            object: nil,
+            queue: nil
+        ) { _ in
+            didReceiveNavigation = true
+        }
+        defer {
+            notificationCenter.removeObserver(observer)
+        }
+
+        let service = DailyReviewPreviewService(
+            appActivator: {
+                didActivateApp = true
+            },
+            notificationCenter: notificationCenter
+        )
+        service.isVisible = true
+
+        service.activateAppAndNavigateToDailyReview()
+
+        XCTAssertFalse(service.isVisible)
+        XCTAssertTrue(didActivateApp)
+        XCTAssertTrue(didReceiveNavigation)
+    }
+
     private func launchSummaryText(_ summary: LaunchSummary) -> String {
         if summary.results.isEmpty {
             return summary.failedCount + summary.rejectedCount == 0 ? "No resources" : "Launched \(summary.launchedCount). \(summary.failedCount + summary.rejectedCount) failed"


### PR DESCRIPTION
# Show Global Shortcut Hints and Fix Preview Activation

Closes #183

## Summary

- Moves the shortcut hint bar to `RootView` as a global bottom-right overlay.
- Adds `⌘⇧U` / Daily Review Preview to the visible shortcut list.
- Routes Daily Review Preview activation through `DailyReviewPreviewService.activateAppAndNavigateToDailyReview()`.
- Uses `NSRunningApplication.current.activate(options: [.activateAllWindows])`, `NSApp.activate(ignoringOtherApps: true)`, and a visible non-preview window focus step before posting the Daily Review navigation notification.
- Adds regression coverage for shortcut list contents and preview activation sequencing.

## Verification

- `xcodegen generate`
  - Created project at `macos/TodoFocusMac/TodoFocusMac.xcodeproj`
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS" -only-testing:CoreTests/FeatureBehaviorTests`
  - `** TEST SUCCEEDED **`
- `xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"`
  - `** TEST SUCCEEDED **`
  - CoreTests: 120 tests, 0 failures
  - DataTests: 53 tests, 0 failures
- `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"`
  - `** BUILD SUCCEEDED **`

## Notes

- Release build still emits the existing widget extension `CFBundleVersion` warning.

