### PR TITLE
Refresh landing page product showcase

### DIFF
--- a/docs/superpowers/issues/2026-04-29-landing-page-product-showcase-refresh.md
+++ b/docs/superpowers/issues/2026-04-29-landing-page-product-showcase-refresh.md
@@ -1,0 +1,20 @@
+# Landing Page Product Showcase Refresh
+
+## Summary
+
+Refresh the TodoFocus landing page so visitors understand the app's core workflow quickly and see the important features through a more polished screenshot showcase.
+
+## Goals
+
+- Improve product understanding for Quick Capture, Deep Focus, Context Launchpad, Daily Review, and local-first storage.
+- Make the screenshot and GIF presentation feel premium, intentional, and easy to scan.
+- Keep the page clean, fast, responsive, and aligned with TodoFocus' native macOS positioning.
+- Preserve the direct download and GitHub release paths.
+
+## Acceptance Criteria
+
+- The landing page leads with a strong product screenshot and clear macOS/local-first positioning.
+- Important features are presented with concise copy and relevant screenshots or GIFs.
+- The screenshot showcase is visually stronger than the current horizontal strip and works on mobile.
+- Metadata and structured data reflect the latest release.
+- Web lint/build verification passes.

--- a/docs/superpowers/plans/2026-04-29-landing-page-product-showcase-refresh.md
+++ b/docs/superpowers/plans/2026-04-29-landing-page-product-showcase-refresh.md
@@ -1,0 +1,53 @@
+# Landing Page Product Showcase Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a clearer, more premium TodoFocus landing page that explains the important app features through a polished product-led showcase.
+
+**Architecture:** Keep the landing page as a static Next.js App Router page. Use small typed arrays for feature/gallery data, existing public screenshots/GIFs, and Tailwind utilities for responsive layouts. Avoid new runtime dependencies.
+
+**Tech Stack:** Next.js 14, React 18, TypeScript, Tailwind CSS, existing static assets.
+
+---
+
+## Chunk 1: Landing Page Refresh
+
+### Task 1: Update metadata and page structure
+
+**Files:**
+- Modify: `web/src/app/layout.tsx`
+- Modify: `web/src/app/page.tsx`
+
+- [x] Update structured data `softwareVersion` to `1.0.9`.
+- [x] Refine metadata copy around native macOS, local-first data, Quick Capture, Deep Focus, Launchpad, and Daily Review.
+- [x] Replace the current centered hero with a product-led hero that includes a large screenshot in the first viewport.
+- [x] Keep primary and secondary CTAs visible near the top.
+
+### Task 2: Build feature showcase sections
+
+**Files:**
+- Modify: `web/src/app/page.tsx`
+
+- [x] Add data arrays for workflow steps, feature spotlights, gallery images, and trust facts.
+- [x] Add a workflow strip for Capture, Plan, Launch, Review.
+- [x] Add feature sections for Quick Capture, Deep Focus, Context Launchpad, Daily Review, and local-first data.
+- [x] Use existing screenshots/GIFs intentionally based on each feature.
+
+### Task 3: Improve visual system details
+
+**Files:**
+- Modify: `web/src/app/globals.css`
+- Modify: `web/src/app/page.tsx`
+
+- [x] Add small reusable CSS utilities for premium surface texture, image rendering, and focus-visible states if needed.
+- [x] Keep the palette restrained and tied to TodoFocus' terracotta/dark UI identity.
+- [x] Ensure mobile layout does not rely on awkward horizontal scrolling.
+
+### Task 4: Verify
+
+**Files:**
+- Test: `web`
+
+- [x] Run `npm run lint` from `web`.
+- [x] Run `npm run build` from `web`.
+- [x] Fix any issues and rerun failing checks.

--- a/docs/superpowers/prs/2026-04-29-landing-page-product-showcase-refresh.md
+++ b/docs/superpowers/prs/2026-04-29-landing-page-product-showcase-refresh.md
@@ -1,0 +1,23 @@
+# Landing Page Product Showcase Refresh
+
+Closes #185
+
+## Summary
+
+- Reworked the web landing page around a product-led TodoFocus workflow: Capture, Choose, Launch, Review.
+- Replaced the simple screenshot strip with feature spotlights, a Launchpad GIF showcase, and an editorial screenshot gallery.
+- Updated SEO/social metadata and structured data copy for the latest native macOS/local-first positioning.
+- Added lightweight implementation/spec/issue artifacts for the change.
+
+## Verification
+
+- `npm run lint`
+  - Result: `No ESLint warnings or errors`
+- `npm run build`
+  - Result: `Compiled successfully`
+  - Result: static route `/` prerendered successfully
+
+## Notes
+
+- Uses existing assets from `web/public`.
+- Keeps static export compatibility with the existing GitHub Pages base path behavior.

--- a/docs/superpowers/specs/2026-04-29-landing-page-product-showcase-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-29-landing-page-product-showcase-refresh-design.md
@@ -1,0 +1,57 @@
+# Landing Page Product Showcase Refresh Design
+
+## Goal
+
+Update the TodoFocus web landing page to prioritize product understanding and premium visual polish while keeping the interface clean and restrained.
+
+## Audience
+
+The page is for macOS users evaluating whether TodoFocus is worth downloading. They should quickly understand that TodoFocus is native, local-first, and built around a focused workday: capture thoughts, choose the right work, launch context, focus, and review.
+
+## Design Direction
+
+Use a product-led layout inspired by the app itself: dark polished surfaces, terracotta accents, subtle warm paper sections, crisp typography, and large real screenshots. Avoid decorative-only visuals. Every image should explain a part of the workflow.
+
+## Page Structure
+
+1. Header
+   - Logo and product name.
+   - Lightweight trust markers.
+   - Download CTA.
+
+2. Hero
+   - Clear headline naming TodoFocus as a native macOS task app.
+   - Short explanation of local-first focus workflow.
+   - Primary download CTA and secondary GitHub/releases CTA.
+   - Large screenshot in a staged product frame, visible in the first viewport.
+
+3. Workflow Strip
+   - Four concise steps: Capture, Plan, Launch, Review.
+   - Designed for quick scanning, not long-form education.
+
+4. Feature Showcases
+   - Quick Capture and Deep Focus: explain system-wide capture and focused execution.
+   - Context Launchpad: use the GIF as the hero media for launching links, files, and apps.
+   - Daily Review and My Day: show review/reset workflow using screenshots.
+   - Local-first data: explain no account, SQLite storage, and import/export.
+
+5. Gallery
+   - Replace the current single horizontal screenshot strip with an editorial gallery using varied image sizes.
+   - Use captions that connect each image to a feature.
+
+6. Final CTA
+   - Repeat download action with macOS requirement and latest release context.
+
+## Implementation Notes
+
+- Keep changes scoped to `web/src/app/page.tsx`, `web/src/app/layout.tsx`, and `web/src/app/globals.css` unless verification requires small supporting updates.
+- Continue using existing assets in `web/public`.
+- Keep static export compatibility by retaining the existing production `assetBase` behavior.
+- Use Tailwind classes and small local data arrays in `page.tsx`; avoid adding dependencies.
+- Update schema `softwareVersion` to `1.0.9`.
+
+## Verification
+
+- Run `npm run lint` in `web`.
+- Run `npm run build` in `web`.
+- Inspect the resulting page structure for responsive image treatment and CTA availability.

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -11,6 +11,7 @@
 
 # next.js
 /.next/
+/.next-dev/
 /out/
 
 # production

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -2,9 +2,11 @@ import { PHASE_DEVELOPMENT_SERVER } from "next/constants.js";
 
 /** @type {import('next').NextConfig} */
 const createNextConfig = (phase) => {
-  const basePath = phase === PHASE_DEVELOPMENT_SERVER ? "" : "/TodoFocus";
+  const isDevelopmentServer = phase === PHASE_DEVELOPMENT_SERVER;
+  const basePath = isDevelopmentServer ? "" : "/TodoFocus";
 
   return {
+    distDir: isDevelopmentServer ? ".next-dev" : ".next",
     output: "export",
     images: {
       unoptimized: true,

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,14 +1,21 @@
-const isProduction = process.env.NODE_ENV === "production";
+import { PHASE_DEVELOPMENT_SERVER } from "next/constants.js";
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: "export",
-  images: {
-    unoptimized: true,
-  },
-  trailingSlash: true,
-  basePath: isProduction ? "/TodoFocus" : "",
-  assetPrefix: isProduction ? "/TodoFocus/" : "",
+const createNextConfig = (phase) => {
+  const basePath = phase === PHASE_DEVELOPMENT_SERVER ? "" : "/TodoFocus";
+
+  return {
+    output: "export",
+    images: {
+      unoptimized: true,
+    },
+    trailingSlash: true,
+    basePath,
+    assetPrefix: basePath ? `${basePath}/` : "",
+    env: {
+      NEXT_PUBLIC_BASE_PATH: basePath,
+    },
+  };
 };
 
-export default nextConfig;
+export default createNextConfig;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -6,4 +6,24 @@
   .text-balance {
     text-wrap: balance;
   }
+
+  .opacity-42 {
+    opacity: 0.42;
+  }
+}
+
+html {
+  background: #f5f0e8;
+}
+
+img {
+  -webkit-user-drag: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+  }
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -23,9 +23,9 @@ const siteUrl = "https://michaelmjhhhh.github.io/TodoFocus";
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
-  title: "TodoFocus | Stop collecting tasks. Start finishing them.",
+  title: "TodoFocus | Native macOS task focus",
   description:
-    "A local-first macOS task app that actually helps you finish things. No cloud, no logins, no nonsense. Just you and your work.",
+    "A native, local-first macOS task app for Quick Capture, Deep Focus, Context Launchpad tasks, Daily Review, and private SQLite storage.",
   keywords: [
     "task manager macOS",
     "productivity app mac",
@@ -57,9 +57,9 @@ export const metadata: Metadata = {
     type: "website",
     url: siteUrl,
     siteName: "TodoFocus",
-    title: "TodoFocus | Stop collecting tasks. Start finishing them.",
+    title: "TodoFocus | Native macOS task focus",
     description:
-      "A local-first macOS task app that actually helps you finish things. No cloud, no logins, no nonsense.",
+      "Capture tasks, launch context, protect focus, and review the day in one local-first macOS workflow.",
     images: [
       {
         url: `${assetBase}/og-image.svg`,
@@ -72,9 +72,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "TodoFocus | Stop collecting tasks. Start finishing them.",
+    title: "TodoFocus | Native macOS task focus",
     description:
-      "A local-first macOS task app that actually helps you finish things. No cloud, no logins, no nonsense.",
+      "Capture tasks, launch context, protect focus, and review the day in one local-first macOS workflow.",
     images: [`${assetBase}/og-image.svg`],
     creator: "@todofocus",
   },

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -18,7 +18,7 @@ const mono = JetBrains_Mono({
   variable: "--font-mono",
 });
 
-const assetBase = process.env.NODE_ENV === "production" ? "/TodoFocus" : "";
+const assetBase = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
 const siteUrl = "https://michaelmjhhhh.github.io/TodoFocus";
 
 export const metadata: Metadata = {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -36,6 +36,7 @@ const featureSpotlights = [
     copy: "The Quick Capture panel makes a thought fast to enter, with voice capture available and routing shown clearly when no Deep Focus session is active.",
     image: "screenshot-03.png",
     alt: "TodoFocus Quick Capture panel",
+    aspectRatio: "1000 / 530",
     stat: "Command Shift T",
   },
   {
@@ -44,6 +45,7 @@ const featureSpotlights = [
     copy: "The Deep Focus status panel shows whether a session is active, how many apps are blocked, and gives quick access back into TodoFocus.",
     image: "screenshot-05.png",
     alt: "TodoFocus Deep Focus status panel",
+    aspectRatio: "676 / 580",
     stat: "Blocked apps + session state",
   },
   {
@@ -52,6 +54,7 @@ const featureSpotlights = [
     copy: "The Daily Review board separates overdue, today, tomorrow, later, and completed work so you can move tasks with a clear sense of status.",
     image: "screenshot-01.png",
     alt: "TodoFocus Daily Review board",
+    aspectRatio: "2940 / 1912",
     stat: "Open, today, tomorrow, done",
   },
 ];
@@ -61,24 +64,28 @@ const galleryItems = [
     image: "screenshot-01.png",
     title: "Daily Review board",
     copy: "A full-screen review surface for open, overdue, today, tomorrow, later, and completed work.",
+    aspectRatio: "2940 / 1912",
     className: "lg:col-span-8",
   },
   {
     image: "screenshot-04.png",
     title: "Menu bar review preview",
     copy: "A compact Daily Review preview shows counts and the tasks needing attention next.",
+    aspectRatio: "668 / 890",
     className: "lg:col-span-4",
   },
   {
     image: "screenshot-02.png",
     title: "All Tasks workspace",
     copy: "Search, time filters, active tasks, completed visibility, and shortcut hints stay in one calm view.",
+    aspectRatio: "2940 / 1912",
     className: "lg:col-span-5",
   },
   {
     image: "screenshot-03.png",
     title: "Quick Capture panel",
     copy: "A focused capture window keeps adding a task lightweight, including microphone capture.",
+    aspectRatio: "1000 / 530",
     className: "lg:col-span-7",
   },
 ];
@@ -298,12 +305,17 @@ export default function Home() {
                       {feature.stat}
                     </div>
                   </div>
-                  <div className="bg-[#141210] p-3 sm:p-5">
-                    <img
-                      src={imagePath(feature.image)}
-                      alt={feature.alt}
-                      className="h-full min-h-[320px] w-full rounded-[1.25rem] object-cover object-left-top"
-                    />
+                  <div className="flex items-center justify-center bg-[#141210] p-3 sm:p-5">
+                    <div
+                      className="w-full overflow-hidden rounded-[1.25rem] bg-[#191715]"
+                      style={{ aspectRatio: feature.aspectRatio }}
+                    >
+                      <img
+                        src={imagePath(feature.image)}
+                        alt={feature.alt}
+                        className="h-full w-full object-contain"
+                      />
+                    </div>
                   </div>
                 </article>
               ))}
@@ -360,11 +372,16 @@ export default function Home() {
                   className={`${item.className} overflow-hidden rounded-[1.5rem] border border-[#2b2722]/10 bg-[#fbf8f1] shadow-[0_26px_80px_rgba(43,39,34,0.14)]`}
                 >
                   <div className="bg-[#161411] p-2.5">
-                    <img
-                      src={imagePath(item.image)}
-                      alt={`${item.title} screenshot`}
-                      className="h-[330px] w-full rounded-[1rem] object-cover object-left-top md:h-[430px]"
-                    />
+                    <div
+                      className="w-full overflow-hidden rounded-[1rem] bg-[#191715]"
+                      style={{ aspectRatio: item.aspectRatio }}
+                    >
+                      <img
+                        src={imagePath(item.image)}
+                        alt={`${item.title} screenshot`}
+                        className="h-full w-full object-contain"
+                      />
+                    </div>
                   </div>
                   <figcaption className="p-5 sm:p-6">
                     <h3 className="font-serif text-2xl text-[#1b1815]">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -92,7 +92,7 @@ const trustFacts = [
 ];
 
 export default function Home() {
-  const assetBase = process.env.NODE_ENV === "production" ? "/TodoFocus" : "";
+  const assetBase = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
 
   const productSchema = {
     "@context": "https://schema.org",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -10,12 +10,12 @@ const workflowSteps = [
   {
     kicker: "01",
     title: "Capture",
-    copy: "Drop thoughts into TodoFocus from anywhere with the global shortcut.",
+    copy: "Open Quick Capture from anywhere and send the thought to Inbox or the active focus task.",
   },
   {
     kicker: "02",
     title: "Choose",
-    copy: "Use My Day, time filters, and clean lists to decide what matters now.",
+    copy: "Search, filter, and pick from the native task list before the day gets crowded.",
   },
   {
     kicker: "03",
@@ -33,52 +33,52 @@ const featureSpotlights = [
   {
     eyebrow: "Quick Capture",
     title: "Capture ideas without leaving the work.",
-    copy: "The system-wide shortcut turns stray thoughts into tasks or appends them to the active Deep Focus task, so context stays intact.",
-    image: "screenshot-05.png",
-    alt: "TodoFocus quick capture and task detail screenshot",
+    copy: "The Quick Capture panel makes a thought fast to enter, with voice capture available and routing shown clearly when no Deep Focus session is active.",
+    image: "screenshot-03.png",
+    alt: "TodoFocus Quick Capture panel",
     stat: "Command Shift T",
   },
   {
     eyebrow: "Deep Focus",
-    title: "Make one task the room.",
-    copy: "Start a focused session, block distracting apps, track focus time, and keep the next action visible until it is done.",
-    image: "screenshot-02.png",
-    alt: "TodoFocus Deep Focus task list screenshot",
-    stat: "Focus timer + stats",
+    title: "Keep focus state close to the menu bar.",
+    copy: "The Deep Focus status panel shows whether a session is active, how many apps are blocked, and gives quick access back into TodoFocus.",
+    image: "screenshot-05.png",
+    alt: "TodoFocus Deep Focus status panel",
+    stat: "Blocked apps + session state",
   },
   {
     eyebrow: "Daily Review",
-    title: "End the day with a clean reset.",
-    copy: "Review overdue, today, tomorrow, and done in a fast native flow that helps you recover momentum instead of reorganizing forever.",
-    image: "screenshot-03.png",
-    alt: "TodoFocus Daily Review preview screenshot",
-    stat: "Overdue to done",
+    title: "Review the day before it becomes clutter.",
+    copy: "The Daily Review board separates overdue, today, tomorrow, later, and completed work so you can move tasks with a clear sense of status.",
+    image: "screenshot-01.png",
+    alt: "TodoFocus Daily Review board",
+    stat: "Open, today, tomorrow, done",
   },
 ];
 
 const galleryItems = [
   {
     image: "screenshot-01.png",
-    title: "Main workspace",
-    copy: "A calm task list with detail, notes, launch resources, and list color context.",
+    title: "Daily Review board",
+    copy: "A full-screen review surface for open, overdue, today, tomorrow, later, and completed work.",
     className: "lg:col-span-8",
   },
   {
     image: "screenshot-04.png",
-    title: "Compact review",
-    copy: "Focused panels keep planning useful without becoming another project.",
+    title: "Menu bar review preview",
+    copy: "A compact Daily Review preview shows counts and the tasks needing attention next.",
     className: "lg:col-span-4",
   },
   {
     image: "screenshot-02.png",
-    title: "Focus surface",
-    copy: "Selection, shortcuts, and task detail stay close to the work.",
+    title: "All Tasks workspace",
+    copy: "Search, time filters, active tasks, completed visibility, and shortcut hints stay in one calm view.",
     className: "lg:col-span-5",
   },
   {
     image: "screenshot-03.png",
-    title: "Daily reset",
-    copy: "Preview tomorrow's shape and clear the loose ends.",
+    title: "Quick Capture panel",
+    copy: "A focused capture window keeps adding a task lightweight, including microphone capture.",
     className: "lg:col-span-7",
   },
 ];
@@ -219,14 +219,14 @@ export default function Home() {
                 </div>
                 <img
                   src={imagePath("screenshot-02.png")}
-                  alt="TodoFocus focus interface"
+                  alt="TodoFocus All Tasks workspace"
                   className="h-[421px] w-full rounded-b-[1.7rem] object-cover object-left-top"
                 />
               </div>
               <div className="absolute bottom-12 left-8 w-[330px] rounded-3xl border border-paper/12 bg-[#191715]/92 p-4 shadow-[0_32px_80px_rgba(0,0,0,0.36)] backdrop-blur">
                 <img
-                  src={imagePath("screenshot-05.png")}
-                  alt="TodoFocus focused task detail"
+                  src={imagePath("screenshot-03.png")}
+                  alt="TodoFocus Quick Capture panel"
                   className="aspect-[1.16] w-full rounded-2xl object-cover"
                 />
                 <div className="mt-4 flex items-center justify-between text-sm">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -3,6 +3,94 @@
 const DIRECT_DOWNLOAD_URL =
   "https://github.com/michaelmjhhhh/TodoFocus/releases/latest/download/TodoFocus-macos-universal.zip";
 
+const RELEASES_URL = "https://github.com/michaelmjhhhh/TodoFocus/releases";
+const REPO_URL = "https://github.com/michaelmjhhhh/TodoFocus";
+
+const workflowSteps = [
+  {
+    kicker: "01",
+    title: "Capture",
+    copy: "Drop thoughts into TodoFocus from anywhere with the global shortcut.",
+  },
+  {
+    kicker: "02",
+    title: "Choose",
+    copy: "Use My Day, time filters, and clean lists to decide what matters now.",
+  },
+  {
+    kicker: "03",
+    title: "Launch",
+    copy: "Open the links, files, and apps attached to the task in one motion.",
+  },
+  {
+    kicker: "04",
+    title: "Review",
+    copy: "Reset overdue work and tomorrow's plan before the day gets noisy.",
+  },
+];
+
+const featureSpotlights = [
+  {
+    eyebrow: "Quick Capture",
+    title: "Capture ideas without leaving the work.",
+    copy: "The system-wide shortcut turns stray thoughts into tasks or appends them to the active Deep Focus task, so context stays intact.",
+    image: "screenshot-05.png",
+    alt: "TodoFocus quick capture and task detail screenshot",
+    stat: "Command Shift T",
+  },
+  {
+    eyebrow: "Deep Focus",
+    title: "Make one task the room.",
+    copy: "Start a focused session, block distracting apps, track focus time, and keep the next action visible until it is done.",
+    image: "screenshot-02.png",
+    alt: "TodoFocus Deep Focus task list screenshot",
+    stat: "Focus timer + stats",
+  },
+  {
+    eyebrow: "Daily Review",
+    title: "End the day with a clean reset.",
+    copy: "Review overdue, today, tomorrow, and done in a fast native flow that helps you recover momentum instead of reorganizing forever.",
+    image: "screenshot-03.png",
+    alt: "TodoFocus Daily Review preview screenshot",
+    stat: "Overdue to done",
+  },
+];
+
+const galleryItems = [
+  {
+    image: "screenshot-01.png",
+    title: "Main workspace",
+    copy: "A calm task list with detail, notes, launch resources, and list color context.",
+    className: "lg:col-span-8",
+  },
+  {
+    image: "screenshot-04.png",
+    title: "Compact review",
+    copy: "Focused panels keep planning useful without becoming another project.",
+    className: "lg:col-span-4",
+  },
+  {
+    image: "screenshot-02.png",
+    title: "Focus surface",
+    copy: "Selection, shortcuts, and task detail stay close to the work.",
+    className: "lg:col-span-5",
+  },
+  {
+    image: "screenshot-03.png",
+    title: "Daily reset",
+    copy: "Preview tomorrow's shape and clear the loose ends.",
+    className: "lg:col-span-7",
+  },
+];
+
+const trustFacts = [
+  "macOS 14+",
+  "Native SwiftUI",
+  "Local SQLite",
+  "No account",
+  "JSON import/export",
+];
+
 export default function Home() {
   const assetBase = process.env.NODE_ENV === "production" ? "/TodoFocus" : "";
 
@@ -11,7 +99,7 @@ export default function Home() {
     "@type": "SoftwareApplication",
     name: "TodoFocus",
     description:
-      "A local-first macOS task app that actually helps you finish things. No cloud, no logins, no nonsense.",
+      "A native, local-first macOS task app for capturing work, launching task context, staying in Deep Focus, and reviewing the day.",
     url: "https://michaelmjhhhh.github.io/TodoFocus",
     applicationCategory: "ProductivityApplication",
     operatingSystem: "macOS 14+",
@@ -20,14 +108,15 @@ export default function Home() {
       price: "0",
       priceCurrency: "USD",
     },
-    downloadUrl:
-      "https://github.com/michaelmjhhhh/TodoFocus/releases/latest/download/TodoFocus-macos-universal.zip",
-    softwareVersion: "1.0.8",
+    downloadUrl: DIRECT_DOWNLOAD_URL,
+    softwareVersion: "1.0.9",
     author: {
       "@type": "Person",
       name: "TodoFocus",
     },
   };
+
+  const imagePath = (name: string) => `${assetBase}/${name}`;
 
   return (
     <>
@@ -35,242 +124,348 @@ export default function Home() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(productSchema) }}
       />
-    <main className="flex min-h-screen flex-col items-center selection:bg-terracotta selection:text-paper overflow-x-hidden">
-      <header className="w-full max-w-4xl mx-auto px-6 py-12 flex justify-between items-center">
-        <div className="flex items-center gap-3">
-          <img
-            src={`${assetBase}/readme-logo.png`}
-            alt="TodoFocus Icon"
-            width={40}
-            height={40}
-            className="rounded-xl shadow-sm"
-          />
-          <span className="font-sans font-medium tracking-tight text-lg text-ink">
-            TodoFocus
-          </span>
-        </div>
-        <a
-          href={DIRECT_DOWNLOAD_URL}
-          className="font-sans text-sm font-medium bg-ink text-paper px-5 py-2.5 rounded-full hover:bg-terracotta transition-colors duration-300"
-        >
-          Download for macOS
-        </a>
-      </header>
-
-      <section className="w-full max-w-3xl mx-auto px-6 py-24 md:py-32 flex flex-col items-center text-center">
-        <h1 className="font-serif text-5xl md:text-7xl font-normal leading-[1.1] text-ink mb-8 tracking-tight text-balance">
-          Stop collecting tasks. <br />
-          <span className="italic text-terracotta">Start finishing them.</span>
-        </h1>
-        <p className="font-sans text-lg md:text-xl text-ink-light max-w-xl mb-12 leading-relaxed text-balance">
-          A local-first macOS task app that actually helps you finish things. No
-          cloud, no logins, no nonsense. Just you and your work.
-        </p>
-        <div className="flex flex-col sm:flex-row items-center gap-4">
-          <a
-            href={DIRECT_DOWNLOAD_URL}
-            className="font-sans text-base font-medium bg-terracotta text-paper px-8 py-4 rounded-full hover:bg-terracotta-hover transition-colors shadow-lg hover:shadow-xl duration-300"
-          >
-            Download Latest Release
-          </a>
-          <a
-            href="https://github.com/michaelmjhhhh/TodoFocus/releases"
-            className="font-sans text-base font-medium bg-transparent text-ink-light border border-ink-lighter/30 px-8 py-4 rounded-full hover:bg-paper-dark hover:text-ink transition-colors duration-300"
-          >
-            View on GitHub
-          </a>
-        </div>
-        <div className="mt-8 flex items-center gap-4 text-xs font-mono text-ink-lighter uppercase tracking-wider">
-          <span>macOS 14+</span>
-          <span>&bull;</span>
-          <span>Native SwiftUI</span>
-          <span>&bull;</span>
-          <span>Local SQLite</span>
-        </div>
-      </section>
-
-      <section className="w-full max-w-5xl mx-auto px-6 mb-32">
-        <div className="flex gap-6 overflow-x-auto pb-4 snap-x snap-mandatory scroll-smooth
-            [&::-webkit-scrollbar]:h-1.5
-            [&::-webkit-scrollbar-track]:bg-ink-lighter/10
-            [&::-webkit-scrollbar-thumb]:bg-ink-lighter/30
-            [&::-webkit-scrollbar-thumb]:rounded-full">
-          {[1, 2, 3, 4, 5].map((n) => (
-            <div
-              key={n}
-              className="flex-shrink-0 w-[480px] md:w-[560px] snap-center"
-            >
-              <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-ink/5 bg-white p-2">
-                <img
-                  src={`${assetBase}/screenshot-0${n}.png`}
-                  alt={`TodoFocus screenshot ${n}`}
-                  className="w-full h-auto rounded-xl"
-                />
-              </div>
-            </div>
-          ))}
-        </div>
-      </section>
-
-
-      <section className="w-full bg-paper-dark py-24 md:py-32">
-        <div className="max-w-2xl mx-auto px-6 text-center">
-          <h2 className="font-serif text-3xl md:text-4xl italic text-ink mb-8">
-            You don&apos;t need another task manager.
-          </h2>
-          <div className="font-sans text-lg md:text-xl text-ink-light space-y-6 leading-relaxed">
-            <p>You already know what to do. You just... don&apos;t do it.</p>
-            <p>
-              Tasks pile up. Tabs multiply. Context disappears. Focus breaks.
-              And suddenly the day is gone.
-            </p>
-            <p className="font-medium text-ink pt-4">
-              Most productivity tools optimize for organization. <br />
-              TodoFocus optimizes for momentum.
-            </p>
-          </div>
-        </div>
-      </section>
-
-
-      <section className="w-full max-w-4xl mx-auto px-6 py-24 md:py-32">
-        <h2 className="font-sans text-sm font-bold uppercase tracking-widest text-terracotta mb-16 text-center">
-          The Method
-        </h2>
-        <div className="grid md:grid-cols-3 gap-12 md:gap-8 relative">
-
-          <div className="hidden md:block absolute top-6 left-[15%] right-[15%] h-px bg-ink-lighter/20 -z-10" />
-
-
-          <div className="flex flex-col items-center text-center">
-            <div className="w-12 h-12 bg-paper border border-ink-lighter/30 rounded-full flex items-center justify-center font-serif text-xl italic text-ink mb-6 shadow-sm">
-              1
-            </div>
-            <h3 className="font-serif text-2xl text-ink mb-4">Capture</h3>
-            <p className="font-sans text-ink-light leading-relaxed">
-              Hit <code className="font-mono text-xs bg-paper-dark px-1.5 py-0.5 rounded">⌘⇧T</code>{" "}
-              from anywhere to capture thoughts instantly without switching context.
-            </p>
-          </div>
-
-
-          <div className="flex flex-col items-center text-center">
-            <div className="w-12 h-12 bg-paper border border-ink-lighter/30 rounded-full flex items-center justify-center font-serif text-xl italic text-ink mb-6 shadow-sm">
-              2
-            </div>
-            <h3 className="font-serif text-2xl text-ink mb-4">Focus</h3>
-            <p className="font-sans text-ink-light leading-relaxed">
-              Start a Deep Focus session. Block distractions, attach links and
-              apps, and commit to the work.
-            </p>
-          </div>
-
-
-          <div className="flex flex-col items-center text-center">
-            <div className="w-12 h-12 bg-paper border border-ink-lighter/30 rounded-full flex items-center justify-center font-serif text-xl italic text-ink mb-6 shadow-sm">
-              3
-            </div>
-            <h3 className="font-serif text-2xl text-ink mb-4">Finish</h3>
-            <p className="font-sans text-ink-light leading-relaxed">
-              Use the Daily Review to clean your day. Overdue, Today, Tomorrow,
-              Done. A fast, honest reset.
-            </p>
-          </div>
-        </div>
-      </section>
-
-
-      <section className="w-full bg-ink text-paper py-24 md:py-32">
-        <div className="max-w-4xl mx-auto px-6">
-          <div className="flex flex-col md:flex-row items-center gap-12">
-            <div className="md:w-1/2">
-              <h2 className="font-serif text-4xl mb-6">Launchpad</h2>
-              <p className="font-sans text-paper/80 text-lg leading-relaxed mb-6">
-                Tasks are not just text. Attach links, files, and apps to your
-                tasks. Then launch everything you need in one click.
-              </p>
-              <p className="font-sans text-paper/80 text-lg leading-relaxed italic">
-                No hunting. No tab archaeology. No &quot;wait, where was that
-                again?&quot;
-              </p>
-            </div>
-            <div className="md:w-1/2">
-              <div className="rounded-xl overflow-hidden shadow-2xl border border-white/10">
-                <img
-                  src={`${assetBase}/demo.gif`}
-                  alt="TodoFocus Launchpad — launch links, files, and apps from a single task"
-                  width={800}
-                  height={600}
-                  className="w-full h-auto"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-
-      <section className="w-full max-w-3xl mx-auto px-6 py-24 md:py-32 text-center">
-        <h2 className="font-serif text-3xl md:text-4xl text-ink mb-6">
-          Your data lives here.
-        </h2>
-        <p className="font-sans text-lg text-ink-light leading-relaxed mb-8">
-          100% local SQLite. No account required. No cloud dependency. JSON
-          import/export for portability.
-        </p>
-        <div className="bg-paper-dark rounded-lg p-6 max-w-xl mx-auto font-mono text-sm text-ink-light text-left overflow-x-auto shadow-inner border border-ink-lighter/20">
-          <code>~/Library/Application Support/todofocus/</code>
-        </div>
-      </section>
-
-
-      <section className="w-full bg-terracotta text-paper py-24 md:py-32 text-center px-6">
-        <h2 className="font-serif text-4xl md:text-6xl mb-8">
-          Ready to finish things?
-        </h2>
-        <a
-          href={DIRECT_DOWNLOAD_URL}
-          className="inline-block font-sans text-lg font-medium bg-paper text-terracotta px-10 py-5 rounded-full hover:bg-white transition-colors shadow-xl duration-300"
-        >
-          Download for macOS
-        </a>
-        <p className="mt-8 font-sans text-paper/80">
-          Requires macOS 14+ Sonoma or later.
-        </p>
-      </section>
-
-
-      <footer className="w-full border-t border-ink-lighter/20 py-12 px-6">
-        <div className="max-w-4xl mx-auto flex flex-col md:flex-row justify-between items-center gap-6">
-          <div className="flex items-center gap-3">
+      <main className="min-h-screen overflow-x-hidden bg-[#f5f0e8] text-[#191715] selection:bg-terracotta selection:text-paper">
+        <section className="relative min-h-[88vh] w-full overflow-hidden bg-[#151311] text-paper">
+          <div className="absolute inset-0">
             <img
-              src={`${assetBase}/readme-logo.png`}
-              alt="TodoFocus Icon"
-              width={24}
-              height={24}
-              className="rounded-md opacity-80 grayscale"
+              src={imagePath("screenshot-01.png")}
+              alt="TodoFocus macOS app interface"
+              className="h-full w-full object-cover opacity-42 saturate-[0.82]"
             />
-            <span className="font-sans text-sm text-ink-light">
-              &copy; {new Date().getFullYear()} TodoFocus. Local-first task manager.
-            </span>
+            <div className="absolute inset-0 bg-[linear-gradient(90deg,rgba(21,19,17,0.98)_0%,rgba(21,19,17,0.86)_34%,rgba(21,19,17,0.42)_72%,rgba(21,19,17,0.66)_100%)]" />
+            <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(21,19,17,0.2)_0%,rgba(21,19,17,0.18)_66%,#f5f0e8_100%)]" />
           </div>
-          <div className="flex gap-6 font-sans text-sm text-ink-light">
+
+          <header className="relative z-10 mx-auto flex w-full max-w-7xl items-center justify-between px-5 py-5 sm:px-8 lg:px-10">
+            <a href="#top" className="flex items-center gap-3 rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-terracotta">
+              <img
+                src={imagePath("readme-logo.png")}
+                alt="TodoFocus icon"
+                width={42}
+                height={42}
+                className="rounded-xl shadow-[0_12px_30px_rgba(0,0,0,0.28)]"
+              />
+              <span className="font-sans text-lg font-semibold tracking-tight">
+                TodoFocus
+              </span>
+            </a>
+            <nav className="hidden items-center gap-7 text-sm text-paper/72 md:flex">
+              <a href="#workflow" className="transition hover:text-paper">
+                Workflow
+              </a>
+              <a href="#features" className="transition hover:text-paper">
+                Features
+              </a>
+              <a href="#gallery" className="transition hover:text-paper">
+                Screenshots
+              </a>
+            </nav>
             <a
-              href="https://github.com/michaelmjhhhh/TodoFocus"
-              className="hover:text-ink transition-colors"
+              href={DIRECT_DOWNLOAD_URL}
+              className="rounded-full bg-paper px-5 py-2.5 text-sm font-semibold text-[#151311] shadow-[0_14px_36px_rgba(0,0,0,0.25)] transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-terracotta"
             >
-              GitHub
+              Download
+            </a>
+          </header>
+
+          <div id="top" className="relative z-10 mx-auto grid w-full max-w-7xl gap-12 px-5 pb-20 pt-20 sm:px-8 md:pb-24 md:pt-28 lg:grid-cols-[0.9fr_1.1fr] lg:px-10">
+            <div className="flex max-w-2xl flex-col justify-center">
+              <div className="mb-6 flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-paper/62">
+                <span className="rounded-full border border-paper/15 bg-paper/8 px-3 py-1.5">
+                  Native macOS
+                </span>
+                <span className="rounded-full border border-paper/15 bg-paper/8 px-3 py-1.5">
+                  Local-first
+                </span>
+              </div>
+              <h1 className="max-w-4xl font-serif text-5xl font-normal leading-[0.97] tracking-tight text-balance sm:text-6xl lg:text-7xl">
+                A task app for actually finishing the day.
+              </h1>
+              <p className="mt-7 max-w-xl text-lg leading-8 text-paper/76 sm:text-xl">
+                TodoFocus turns capture, planning, task context, focus sessions,
+                and daily review into one native macOS workflow. No account. No
+                cloud dependency. No productivity theater.
+              </p>
+              <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+                <a
+                  href={DIRECT_DOWNLOAD_URL}
+                  className="inline-flex items-center justify-center rounded-full bg-terracotta px-7 py-4 text-base font-semibold text-paper shadow-[0_18px_48px_rgba(196,104,73,0.32)] transition hover:bg-terracotta-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-paper"
+                >
+                  Download for macOS
+                </a>
+                <a
+                  href={RELEASES_URL}
+                  className="inline-flex items-center justify-center rounded-full border border-paper/18 bg-paper/8 px-7 py-4 text-base font-semibold text-paper transition hover:border-paper/36 hover:bg-paper/12 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-paper"
+                >
+                  View releases
+                </a>
+              </div>
+              <div className="mt-8 flex flex-wrap gap-x-4 gap-y-2 text-sm text-paper/58">
+                {trustFacts.slice(0, 4).map((fact) => (
+                  <span key={fact} className="flex items-center gap-2">
+                    <span className="h-1.5 w-1.5 rounded-full bg-terracotta" />
+                    {fact}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div className="relative hidden min-h-[520px] items-center lg:flex">
+              <div className="absolute -right-16 top-10 h-[460px] w-[660px] rounded-[2rem] border border-paper/10 bg-[#22201d]/82 shadow-[0_44px_110px_rgba(0,0,0,0.42)] backdrop-blur">
+                <div className="flex h-9 items-center gap-2 border-b border-paper/10 px-4">
+                  <span className="h-3 w-3 rounded-full bg-[#ff6159]" />
+                  <span className="h-3 w-3 rounded-full bg-[#ffbd2e]" />
+                  <span className="h-3 w-3 rounded-full bg-[#28c840]" />
+                </div>
+                <img
+                  src={imagePath("screenshot-02.png")}
+                  alt="TodoFocus focus interface"
+                  className="h-[421px] w-full rounded-b-[1.7rem] object-cover object-left-top"
+                />
+              </div>
+              <div className="absolute bottom-12 left-8 w-[330px] rounded-3xl border border-paper/12 bg-[#191715]/92 p-4 shadow-[0_32px_80px_rgba(0,0,0,0.36)] backdrop-blur">
+                <img
+                  src={imagePath("screenshot-05.png")}
+                  alt="TodoFocus focused task detail"
+                  className="aspect-[1.16] w-full rounded-2xl object-cover"
+                />
+                <div className="mt-4 flex items-center justify-between text-sm">
+                  <span className="font-medium text-paper">Quick Capture</span>
+                  <span className="font-mono text-paper/52">Command Shift T</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="workflow" className="relative mx-auto -mt-10 w-full max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="grid gap-px overflow-hidden rounded-[1.75rem] border border-[#2b2722]/10 bg-[#2b2722]/10 shadow-[0_30px_90px_rgba(43,39,34,0.16)] md:grid-cols-4">
+            {workflowSteps.map((step) => (
+              <div key={step.title} className="bg-[#fbf8f1] p-6 md:p-7">
+                <div className="font-mono text-xs font-semibold text-terracotta">
+                  {step.kicker}
+                </div>
+                <h2 className="mt-5 font-serif text-3xl text-[#1b1815]">
+                  {step.title}
+                </h2>
+                <p className="mt-3 text-sm leading-6 text-[#625a50]">
+                  {step.copy}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mx-auto w-full max-w-7xl px-5 py-24 sm:px-8 md:py-32 lg:px-10">
+          <div className="grid gap-12 lg:grid-cols-[0.8fr_1.2fr] lg:items-end">
+            <div>
+              <p className="font-mono text-sm font-semibold uppercase tracking-[0.24em] text-terracotta">
+                Product clarity
+              </p>
+              <h2 className="mt-4 max-w-2xl font-serif text-4xl leading-tight tracking-tight text-[#1b1815] sm:text-5xl">
+                Every major feature maps to a moment in the workday.
+              </h2>
+            </div>
+            <p className="max-w-2xl text-lg leading-8 text-[#625a50]">
+              TodoFocus is not a storage cabinet for obligations. It is a
+              compact loop: catch the thought, pick the right task, launch its
+              context, protect attention, and review what changed.
+            </p>
+          </div>
+        </section>
+
+        <section id="features" className="w-full bg-[#191715] py-24 text-paper md:py-32">
+          <div className="mx-auto w-full max-w-7xl px-5 sm:px-8 lg:px-10">
+            <div className="grid gap-6">
+              {featureSpotlights.map((feature, index) => (
+                <article
+                  key={feature.title}
+                  className="grid overflow-hidden rounded-[1.75rem] border border-paper/10 bg-[#211e1a] shadow-[0_28px_90px_rgba(0,0,0,0.28)] lg:grid-cols-2"
+                >
+                  <div className={`flex flex-col justify-between p-7 sm:p-10 ${index % 2 === 1 ? "lg:order-2" : ""}`}>
+                    <div>
+                      <p className="font-mono text-xs font-semibold uppercase tracking-[0.24em] text-terracotta">
+                        {feature.eyebrow}
+                      </p>
+                      <h3 className="mt-5 max-w-lg font-serif text-4xl leading-tight tracking-tight sm:text-5xl">
+                        {feature.title}
+                      </h3>
+                      <p className="mt-5 max-w-xl text-lg leading-8 text-paper/68">
+                        {feature.copy}
+                      </p>
+                    </div>
+                    <div className="mt-10 inline-flex w-fit rounded-full border border-paper/12 bg-paper/8 px-4 py-2 font-mono text-xs uppercase tracking-[0.18em] text-paper/66">
+                      {feature.stat}
+                    </div>
+                  </div>
+                  <div className="bg-[#141210] p-3 sm:p-5">
+                    <img
+                      src={imagePath(feature.image)}
+                      alt={feature.alt}
+                      className="h-full min-h-[320px] w-full rounded-[1.25rem] object-cover object-left-top"
+                    />
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="w-full bg-[#f5f0e8] py-24 md:py-32">
+          <div className="mx-auto grid w-full max-w-7xl gap-10 px-5 sm:px-8 lg:grid-cols-[0.75fr_1.25fr] lg:px-10">
+            <div className="lg:pt-12">
+              <p className="font-mono text-sm font-semibold uppercase tracking-[0.24em] text-terracotta">
+                Context Launchpad
+              </p>
+              <h2 className="mt-4 font-serif text-4xl leading-tight tracking-tight text-[#1b1815] sm:text-5xl">
+                Tasks can carry the tools needed to finish them.
+              </h2>
+              <p className="mt-6 text-lg leading-8 text-[#625a50]">
+                Add URLs, files, and apps to a task, then launch the whole
+                workspace when you are ready. The task becomes the doorway back
+                into the actual work.
+              </p>
+            </div>
+            <div className="overflow-hidden rounded-[1.75rem] border border-[#2b2722]/10 bg-[#151311] p-3 shadow-[0_34px_100px_rgba(43,39,34,0.22)]">
+              <img
+                src={imagePath("demo.gif")}
+                alt="TodoFocus Launchpad opening task resources"
+                className="w-full rounded-[1.25rem] object-cover"
+              />
+            </div>
+          </div>
+        </section>
+
+        <section id="gallery" className="w-full bg-[#ede7dc] py-24 md:py-32">
+          <div className="mx-auto w-full max-w-7xl px-5 sm:px-8 lg:px-10">
+            <div className="mb-12 flex flex-col justify-between gap-6 lg:flex-row lg:items-end">
+              <div>
+                <p className="font-mono text-sm font-semibold uppercase tracking-[0.24em] text-terracotta">
+                  Screenshot gallery
+                </p>
+                <h2 className="mt-4 max-w-2xl font-serif text-4xl leading-tight tracking-tight text-[#1b1815] sm:text-5xl">
+                  A cleaner look at the surfaces you will use every day.
+                </h2>
+              </div>
+              <p className="max-w-md text-base leading-7 text-[#625a50]">
+                Each view is organized around action: what needs attention, what
+                context belongs to the task, and what can be finished now.
+              </p>
+            </div>
+
+            <div className="grid gap-5 lg:grid-cols-12">
+              {galleryItems.map((item) => (
+                <figure
+                  key={item.title}
+                  className={`${item.className} overflow-hidden rounded-[1.5rem] border border-[#2b2722]/10 bg-[#fbf8f1] shadow-[0_26px_80px_rgba(43,39,34,0.14)]`}
+                >
+                  <div className="bg-[#161411] p-2.5">
+                    <img
+                      src={imagePath(item.image)}
+                      alt={`${item.title} screenshot`}
+                      className="h-[330px] w-full rounded-[1rem] object-cover object-left-top md:h-[430px]"
+                    />
+                  </div>
+                  <figcaption className="p-5 sm:p-6">
+                    <h3 className="font-serif text-2xl text-[#1b1815]">
+                      {item.title}
+                    </h3>
+                    <p className="mt-2 text-sm leading-6 text-[#625a50]">
+                      {item.copy}
+                    </p>
+                  </figcaption>
+                </figure>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="w-full bg-[#191715] py-24 text-paper md:py-32">
+          <div className="mx-auto grid w-full max-w-7xl gap-10 px-5 sm:px-8 lg:grid-cols-[1fr_1fr] lg:items-center lg:px-10">
+            <div>
+              <p className="font-mono text-sm font-semibold uppercase tracking-[0.24em] text-terracotta">
+                Local-first by default
+              </p>
+              <h2 className="mt-4 font-serif text-4xl leading-tight tracking-tight sm:text-5xl">
+                Your task system lives on your Mac.
+              </h2>
+              <p className="mt-6 text-lg leading-8 text-paper/68">
+                TodoFocus stores data in local SQLite, works without an account,
+                and keeps portability available through JSON import and export.
+              </p>
+            </div>
+            <div className="rounded-[1.5rem] border border-paper/10 bg-paper/6 p-6 shadow-[0_28px_90px_rgba(0,0,0,0.24)]">
+              <div className="mb-5 flex flex-wrap gap-2">
+                {trustFacts.map((fact) => (
+                  <span
+                    key={fact}
+                    className="rounded-full border border-paper/10 bg-paper/8 px-3 py-1.5 text-sm text-paper/72"
+                  >
+                    {fact}
+                  </span>
+                ))}
+              </div>
+              <div className="overflow-x-auto rounded-2xl border border-paper/10 bg-[#11100e] p-5 font-mono text-sm text-paper/72">
+                ~/Library/Application Support/todofocus/
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="w-full bg-terracotta px-5 py-20 text-center text-paper sm:px-8 md:py-28">
+          <h2 className="mx-auto max-w-3xl font-serif text-4xl leading-tight tracking-tight sm:text-6xl">
+            Start with the next task, not another system.
+          </h2>
+          <p className="mx-auto mt-5 max-w-xl text-lg leading-8 text-paper/78">
+            Latest release: v1.0.9. Requires macOS 14 Sonoma or later.
+          </p>
+          <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <a
+              href={DIRECT_DOWNLOAD_URL}
+              className="inline-flex rounded-full bg-paper px-8 py-4 text-base font-semibold text-terracotta shadow-[0_18px_48px_rgba(90,36,20,0.24)] transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-paper"
+            >
+              Download TodoFocus
             </a>
             <a
-              href="https://github.com/michaelmjhhhh/TodoFocus/issues"
-              className="hover:text-ink transition-colors"
+              href={REPO_URL}
+              className="inline-flex rounded-full border border-paper/28 px-8 py-4 text-base font-semibold text-paper transition hover:bg-paper/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-paper"
             >
-              Feedback
+              View source
             </a>
           </div>
-        </div>
-      </footer>
-    </main>
+        </section>
+
+        <footer className="w-full border-t border-[#2b2722]/10 bg-[#f5f0e8] px-5 py-10 sm:px-8">
+          <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 md:flex-row md:items-center md:justify-between">
+            <div className="flex items-center gap-3">
+              <img
+                src={imagePath("readme-logo.png")}
+                alt="TodoFocus icon"
+                width={28}
+                height={28}
+                className="rounded-lg"
+              />
+              <span className="text-sm text-[#625a50]">
+                TodoFocus. Native, local-first task focus for macOS.
+              </span>
+            </div>
+            <div className="flex gap-6 text-sm text-[#625a50]">
+              <a href={REPO_URL} className="transition hover:text-[#1b1815]">
+                GitHub
+              </a>
+              <a
+                href="https://github.com/michaelmjhhhh/TodoFocus/issues"
+                className="transition hover:text-[#1b1815]"
+              >
+                Feedback
+              </a>
+              <a href={RELEASES_URL} className="transition hover:text-[#1b1815]">
+                Releases
+              </a>
+            </div>
+          </div>
+        </footer>
+      </main>
     </>
   );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -223,11 +223,11 @@ export default function Home() {
                   className="h-[421px] w-full rounded-b-[1.7rem] object-cover object-left-top"
                 />
               </div>
-              <div className="absolute bottom-12 left-8 w-[330px] rounded-3xl border border-paper/12 bg-[#191715]/92 p-4 shadow-[0_32px_80px_rgba(0,0,0,0.36)] backdrop-blur">
+              <div className="absolute bottom-12 left-8 w-[380px] rounded-3xl border border-paper/12 bg-[#191715]/92 p-3 shadow-[0_32px_80px_rgba(0,0,0,0.36)] backdrop-blur">
                 <img
                   src={imagePath("screenshot-03.png")}
                   alt="TodoFocus Quick Capture panel"
-                  className="aspect-[1.16] w-full rounded-2xl object-cover"
+                  className="aspect-[1000/530] w-full rounded-2xl bg-[#191715] object-contain"
                 />
                 <div className="mt-4 flex items-center justify-between text-sm">
                   <span className="font-medium text-paper">Quick Capture</span>

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -21,6 +21,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next-dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# Landing Page Product Showcase Refresh

Closes #185

## Summary

- Reworked the web landing page around a product-led TodoFocus workflow: Capture, Choose, Launch, Review.
- Replaced the simple screenshot strip with feature spotlights, a Launchpad GIF showcase, and an editorial screenshot gallery.
- Updated SEO/social metadata and structured data copy for the latest native macOS/local-first positioning.
- Added lightweight implementation/spec/issue artifacts for the change.

## Verification

- `npm run lint`
  - Result: `No ESLint warnings or errors`
- `npm run build`
  - Result: `Compiled successfully`
  - Result: static route `/` prerendered successfully

## Notes

- Uses existing assets from `web/public`.
- Keeps static export compatibility with the existing GitHub Pages base path behavior.
