### PR TITLE
Polish shortcut bar and remove count badges

### DIFF
--- a/macos/TodoFocusMac/Sources/Features/Common/ShortcutHintBar.swift
+++ b/macos/TodoFocusMac/Sources/Features/Common/ShortcutHintBar.swift
@@ -5,6 +5,24 @@ struct ShortcutHintItem: Identifiable, Equatable {
     let action: String
 
     var id: String { key }
+    var shortAction: String {
+        switch action {
+        case "Global Quick Capture":
+            return "Capture"
+        case "Daily Review Preview":
+            return "Review"
+        case "Start Deep Focus":
+            return "Focus"
+        case "Search Tasks":
+            return "Search"
+        case "Toggle Theme":
+            return "Theme"
+        case "New Task":
+            return "New"
+        default:
+            return action
+        }
+    }
 }
 
 struct ShortcutHintBar: View {
@@ -17,70 +35,78 @@ struct ShortcutHintBar: View {
         ShortcutHintItem(key: "⌘⇧N", action: "New Task")
     ]
 
+    private static let visibleShortcutKeys = ["⌘⇧T", "⌘⇧U", "⌘K", "⌘⇧F", "⌘⇧N"]
+    private static var visibleShortcuts: [ShortcutHintItem] {
+        visibleShortcutKeys.compactMap { key in
+            availableShortcuts.first { $0.key == key }
+        }
+    }
+
     var needsAccessibilityPermission: Bool = false
     var onRequestPermission: (() -> Void)?
     @Environment(\.themeTokens) private var tokens
 
     var body: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: 8) {
             if needsAccessibilityPermission {
                 permissionWarning
+                dotSeparator
             }
-            
-            Spacer()
 
-            HStack(spacing: 12) {
-                ForEach(Self.availableShortcuts) { shortcut in
-                    shortcutPill(shortcut.key, shortcut.action)
+            HStack(spacing: 7) {
+                ForEach(Array(Self.visibleShortcuts.enumerated()), id: \.element.id) { index, shortcut in
+                    shortcutHint(shortcut)
+                    if index < Self.visibleShortcuts.count - 1 {
+                        dotSeparator
+                    }
                 }
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 11)
+        .padding(.vertical, 5)
         .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(tokens.bgFloating.opacity(0.8))
+            Capsule()
+                .fill(tokens.bgFloating.opacity(0.30))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(tokens.sectionBorder, lineWidth: 1)
+                    Capsule()
+                        .stroke(tokens.sectionBorder.opacity(0.18), lineWidth: 1)
                 )
         )
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private var dotSeparator: some View {
+        Text("·")
+            .font(.caption2)
+            .foregroundStyle(tokens.textTertiary.opacity(0.28))
     }
     
     private var permissionWarning: some View {
         Button {
             onRequestPermission?()
         } label: {
-            HStack(spacing: 6) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-                Text("Enable Accessibility for ⌘⇧T")
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.orange)
+            HStack(spacing: 4) {
+                Image(systemName: "lock.open.fill")
+                    .font(.caption2)
+                Text("Quick Capture access")
+                    .font(.caption2.weight(.semibold))
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(.orange.opacity(0.15))
-            )
+            .foregroundStyle(tokens.accentTerracotta.opacity(0.66))
         }
         .buttonStyle(.plain)
+        .help("Enable Accessibility permission for Global Quick Capture")
     }
 
-    private func shortcutPill(_ key: String, _ action: String) -> some View {
-        HStack(spacing: 4) {
-            Text(key)
+    private func shortcutHint(_ shortcut: ShortcutHintItem) -> some View {
+        HStack(spacing: 5) {
+            Text(shortcut.shortAction)
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(tokens.textSecondary.opacity(0.86))
+            Text(shortcut.key)
                 .font(.caption2.weight(.semibold).monospaced())
-                .foregroundStyle(tokens.textPrimary)
-            Text(action)
-                .font(.caption2)
-                .foregroundStyle(tokens.textTertiary)
+                .foregroundStyle(tokens.textTertiary.opacity(0.72))
         }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 3)
-        .background(tokens.sectionBackground, in: Capsule())
+        .help(shortcut.action)
     }
 }
 

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewPreviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewPreviewView.swift
@@ -13,11 +13,9 @@ struct DailyReviewPreviewView: View {
         let snapshot = DailyReviewPreviewSnapshot.shaped(from: board, maxRowsPerBucket: 4)
         let totalOpen = snapshot.openTasks.reduce(0) { $0 + $1.tasks.count }
         let totalCompleted = snapshot.completedTasks.reduce(0) { $0 + $1.tasks.count }
-        let overdueOpen = snapshot.openTasks.first(where: { $0.bucket == .overdue })?.tasks.count ?? 0
-        let todayOpen = snapshot.openTasks.first(where: { $0.bucket == .today })?.tasks.count ?? 0
         
         VStack(spacing: 18) {
-            header(totalOpen: totalOpen, totalCompleted: totalCompleted, overdueOpen: overdueOpen, todayOpen: todayOpen)
+            header
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
@@ -62,7 +60,7 @@ struct DailyReviewPreviewView: View {
         )
     }
 
-    private func header(totalOpen: Int, totalCompleted: Int, overdueOpen: Int, todayOpen: Int) -> some View {
+    private var header: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .center, spacing: 10) {
                 Image(systemName: "calendar.day.timeline.left")
@@ -102,29 +100,6 @@ struct DailyReviewPreviewView: View {
                 .accessibilityLabel("Close preview")
             }
 
-            ViewThatFits(in: .horizontal) {
-                HStack(spacing: 8) {
-                    metricPill(title: "Open", value: totalOpen)
-                    metricPill(title: "Today", value: todayOpen)
-                    metricPill(title: "Overdue", value: overdueOpen)
-                    if totalCompleted > 0 {
-                        metricPill(title: "Done", value: totalCompleted)
-                    }
-                }
-                
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(spacing: 8) {
-                        metricPill(title: "Open", value: totalOpen)
-                        metricPill(title: "Today", value: todayOpen)
-                    }
-                    HStack(spacing: 8) {
-                        metricPill(title: "Overdue", value: overdueOpen)
-                        if totalCompleted > 0 {
-                            metricPill(title: "Done", value: totalCompleted)
-                        }
-                    }
-                }
-            }
         }
     }
 
@@ -189,29 +164,6 @@ struct DailyReviewPreviewView: View {
         .overlay {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .stroke(tokens.sectionBorder.opacity(0.75), lineWidth: 1)
-        }
-    }
-
-    private func metricPill(title: String, value: Int) -> some View {
-        HStack(spacing: 6) {
-            Text(title)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(tokens.textSecondary)
-                .lineLimit(1)
-            Text("\(value)")
-                .font(.caption.weight(.bold))
-                .monospacedDigit()
-                .foregroundStyle(tokens.textPrimary)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(tokens.bgFloating.opacity(0.9), in: Capsule())
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
-        .background(tokens.sectionBackground, in: Capsule())
-        .overlay {
-            Capsule()
-                .stroke(tokens.sectionBorder, lineWidth: 1)
         }
     }
 

--- a/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Review/DailyReviewView.swift
@@ -109,7 +109,6 @@ struct DailyReviewView: View {
                     .foregroundStyle(tokens.textTertiary)
             }
             Spacer(minLength: 8)
-            metricPill(title: "All Tasks", value: store.todoCount)
         }
     }
 
@@ -134,13 +133,6 @@ struct DailyReviewView: View {
                     Text(title)
                         .font(.headline.weight(.semibold))
                         .foregroundStyle(Color.white)
-                    Text("\(columns.reduce(0) { $0 + $1.todos.count })")
-                        .font(.caption.weight(.bold))
-                        .monospacedDigit()
-                        .foregroundStyle(tokens.textSecondary)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .background(tokens.bgFloating.opacity(0.8), in: Capsule())
                     Spacer(minLength: 8)
                     if isCompletedLane {
                         Image(systemName: collapsed ? "chevron.right" : "chevron.down")
@@ -181,13 +173,6 @@ struct DailyReviewView: View {
                 Text(column.bucket.title)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(tokens.textPrimary)
-                Text("\(column.todos.count)")
-                    .font(.caption.weight(.bold))
-                    .monospacedDigit()
-                    .foregroundStyle(tokens.textSecondary)
-                    .padding(.horizontal, 7)
-                    .padding(.vertical, 2)
-                    .background(tokens.bgFloating.opacity(0.8), in: Capsule())
                 Spacer(minLength: 6)
                 Button {
                     boardViewModel.toggleColumn(bucket: column.bucket, lane: lane)
@@ -261,28 +246,6 @@ struct DailyReviewView: View {
                 .frame(width: 3)
                 .padding(.vertical, 7)
                 .padding(.leading, 5)
-        }
-    }
-
-    private func metricPill(title: String, value: Int) -> some View {
-        HStack(spacing: 7) {
-            Text(title)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(tokens.textSecondary)
-            Text("\(value)")
-                .font(.caption.weight(.bold))
-                .monospacedDigit()
-                .foregroundStyle(tokens.textPrimary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .background(tokens.bgFloating.opacity(0.9), in: Capsule())
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .background(tokens.sectionBackground, in: Capsule())
-        .overlay {
-            Capsule()
-                .stroke(tokens.sectionBorder, lineWidth: 1)
         }
     }
 

--- a/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
+++ b/macos/TodoFocusMac/Sources/Features/Sidebar/SidebarView.swift
@@ -21,13 +21,13 @@ struct SidebarView: View {
     var body: some View {
         List {
             Section {
-                smartRow("Daily Review", systemImage: "checklist", selection: .dailyReview, count: store.todoCount)
-                smartRow("My Day", systemImage: "sun.max", selection: .myDay, count: store.myDayCount)
-                smartRow("Important", systemImage: "star", selection: .important, count: store.importantCount)
-                smartRow("Planned", systemImage: "calendar", selection: .planned, count: store.plannedCount)
-                smartRow("Overdue", systemImage: "exclamationmark.triangle", selection: .overdue, count: store.overdueCount)
-                smartRow("All Tasks", systemImage: "tray.full", selection: .all, count: store.todoCount)
-                smartRow("Archive", systemImage: "archivebox", selection: .archive, count: store.archivedCount)
+                smartRow("Daily Review", systemImage: "checklist", selection: .dailyReview)
+                smartRow("My Day", systemImage: "sun.max", selection: .myDay)
+                smartRow("Important", systemImage: "star", selection: .important)
+                smartRow("Planned", systemImage: "calendar", selection: .planned)
+                smartRow("Overdue", systemImage: "exclamationmark.triangle", selection: .overdue)
+                smartRow("All Tasks", systemImage: "tray.full", selection: .all)
+                smartRow("Archive", systemImage: "archivebox", selection: .archive)
             }
 
             Section {
@@ -65,13 +65,12 @@ struct SidebarView: View {
         .animation(.easeInOut(duration: 0.15), value: lists.count)
     }
 
-    private func smartRow(_ title: String, systemImage: String, selection: SidebarSelection, count: Int? = nil) -> some View {
+    private func smartRow(_ title: String, systemImage: String, selection: SidebarSelection) -> some View {
         SidebarRowButton(
             title: title,
             systemImage: systemImage,
             listColor: nil,
             isSelected: appModel.selection == selection,
-            count: count,
             action: {
                 withAnimation(MotionTokens.focusEase) {
                     appModel.selectSidebar(selection)
@@ -248,7 +247,6 @@ private struct SidebarRowButton: View {
     let systemImage: String
     let listColor: Color?
     let isSelected: Bool
-    let count: Int?
     let action: () -> Void
     @State private var isHovered: Bool = false
     @Environment(\.themeTokens) private var tokens
@@ -271,20 +269,6 @@ private struct SidebarRowButton: View {
                     .foregroundStyle(isSelected ? tokens.textPrimary : tokens.textSecondary)
 
                 Spacer(minLength: 0)
-
-                if let count {
-                    Text("\(count)")
-                        .font(.caption2.weight(.semibold))
-                        .monospacedDigit()
-                        .foregroundStyle(isSelected ? tokens.textSecondary : tokens.textTertiary)
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, 2)
-                        .background(tokens.bgFloating.opacity(0.58), in: Capsule())
-                        .overlay {
-                            Capsule()
-                                .stroke(tokens.sectionBorder.opacity(0.82), lineWidth: 1)
-                        }
-                }
 
                 Image(systemName: "checkmark")
                     .font(.system(size: 10, weight: .bold))
@@ -336,7 +320,6 @@ private struct SidebarListItemView: View {
             systemImage: "list.bullet",
             listColor: Color(hex: list.color),
             isSelected: appModel.selection == .customList(list.id),
-            count: store.countForList(list.id),
             action: {
                 withAnimation(MotionTokens.focusEase) {
                     appModel.selectSidebar(.customList(list.id))

--- a/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskList/TaskListView.swift
@@ -57,18 +57,6 @@ struct TaskListView: View {
                     filterPicker
                 }
 
-                Text("\(filteredTodosCache.count)")
-                    .font(.caption.weight(.semibold))
-                    .monospacedDigit()
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 4)
-                    .foregroundStyle(tokens.textSecondary)
-                    .background(tokens.bgFloating.opacity(0.85), in: Capsule())
-                    .overlay {
-                        Capsule()
-                            .stroke(tokens.sectionBorder.opacity(0.9), lineWidth: 1)
-                    }
-
                 if isArchiveView {
                     Button(role: .destructive) {
                         showEmptyArchiveConfirmation = true
@@ -105,13 +93,6 @@ struct TaskListView: View {
                             Text("Completed")
                                 .font(.caption.weight(.semibold))
                                 .foregroundStyle(isCompletedPanelVisible ? tokens.textSecondary : tokens.textTertiary)
-                            Text("\(completedTodosCache.count)")
-                                .font(.caption.weight(.semibold))
-                                .monospacedDigit()
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .foregroundStyle(isCompletedPanelVisible ? tokens.textPrimary : tokens.textSecondary)
-                                .background(tokens.bgFloating.opacity(0.95), in: Capsule())
                         }
                         .padding(.horizontal, 10)
                         .padding(.vertical, 5)
@@ -353,9 +334,6 @@ struct TaskListView: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(tokens.mutedText)
                 Spacer()
-                Text("\(todos.count)")
-                    .font(.caption2)
-                    .foregroundStyle(tokens.mutedText)
             }
 
             ScrollView {
@@ -419,13 +397,6 @@ struct TaskListView: View {
                     }
                 }
                 .buttonStyle(.plain)
-
-                Text("\(todos.count)")
-                    .font(.caption2.weight(.medium))
-                    .foregroundStyle(tokens.textTertiary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(tokens.bgFloating, in: Capsule())
 
                 Spacer()
 

--- a/macos/TodoFocusMac/Sources/RootView.swift
+++ b/macos/TodoFocusMac/Sources/RootView.swift
@@ -147,15 +147,14 @@ struct RootView: View {
         }
         .immersiveHeader(isExpanded: $isHeaderExpanded, isSidebarVisible: $isSidebarVisible)
         .environment(\.themeTokens, themeTokens)
-        .overlay(alignment: .bottomTrailing) {
-            ZStack(alignment: .bottomTrailing) {
+        .overlay(alignment: .bottom) {
+            ZStack(alignment: .bottom) {
                 ShortcutHintBar(
                     needsAccessibilityPermission: appModel.quickCaptureService.needsAccessibilityPermission,
                     onRequestPermission: {
                         appModel.quickCaptureService.requestAccessibilityPermission()
                     }
                 )
-                .padding(.trailing, 16)
                 .padding(.bottom, 16)
 
                 Button("") {


### PR DESCRIPTION
## Summary
- Refine the bottom shortcut hint bar into a lighter centered strip
- Remove task/list count badges from sidebar, task list headers, completed controls, Daily Review, and Daily Review preview
- Keep review shortcut visible while hiding the theme shortcut from the hint strip

## Verification
- xcodebuild test -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"
- xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -configuration Release -derivedDataPath "macos/TodoFocusMac/build/DerivedData" -destination "platform=macOS"