### PR TITLE
Group Deep Focus modal sections into cards; unify task header

### DIFF
--- a/macos/TodoFocusMac/Sources/Features/Common/SectionCard.swift
+++ b/macos/TodoFocusMac/Sources/Features/Common/SectionCard.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct SectionCardStyle: ViewModifier {
+    @Environment(\.themeTokens) private var tokens
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.horizontal, SpacingTokens.lg)
+            .padding(.vertical, SpacingTokens.lg)
+            .background(
+                tokens.bgSubtle,
+                in: RoundedRectangle(cornerRadius: RadiusTokens.lg, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: RadiusTokens.lg, style: .continuous)
+                    .stroke(tokens.sectionBorder, lineWidth: 1)
+            }
+            .shadowMedium()
+    }
+}
+
+extension View {
+    func sectionCard() -> some View { modifier(SectionCardStyle()) }
+}

--- a/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
+++ b/macos/TodoFocusMac/Sources/Features/TaskDetail/TaskDetailView.swift
@@ -38,7 +38,6 @@ struct TaskDetailView: View {
 
                 ScrollView {
                     VStack(alignment: .leading, spacing: 16) {
-                        dateSection(todo: todo)
                         if todo.focusTimeSeconds > 0 {
                             focusTimeSection(todo: todo)
                         }
@@ -145,7 +144,7 @@ struct TaskDetailView: View {
         let titleStrokeWidth: CGFloat = (hasValidationError || isTitleFocused) ? 1.2 : 0
         let titleGlowOpacity: Double = (isTitleFocused && !hasValidationError) ? 0.52 : 0
 
-        return VStack(alignment: .leading, spacing: SpacingTokens.sm) {
+        return VStack(alignment: .leading, spacing: SpacingTokens.lg) {
             HStack(spacing: SpacingTokens.sm) {
                 VStack(alignment: .leading, spacing: SpacingTokens.sm) {
                     TextField("Task title", text: $titleText)
@@ -222,18 +221,9 @@ struct TaskDetailView: View {
                     .accessibilityLabel("Close detail")
                     .help("Close detail")
                 }
-                .padding(.horizontal, SpacingTokens.sm)
-                .padding(.vertical, SpacingTokens.xs)
-                .background(
-                    RoundedRectangle(cornerRadius: RadiusTokens.md, style: .continuous)
-                        .fill(isTitleFocused ? tokens.inputSurface : Color.clear)
-                )
-                .overlay {
-                    RoundedRectangle(cornerRadius: RadiusTokens.md, style: .continuous)
-                        .stroke(titleStrokeColor, lineWidth: titleStrokeWidth)
-                }
-                .animation(MotionTokens.focusEase, value: isTitleFocused)
             }
+
+            dateSection(todo: todo)
         }
         .padding(.horizontal, SpacingTokens.lg)
         .padding(.top, SpacingTokens.xl - SpacingTokens.xs)
@@ -863,11 +853,12 @@ struct DeepFocusSetupSheet: View {
                 }
             }
         }
-        .padding(.horizontal, 20)
+        .sectionCard()
+        .padding(.horizontal, SpacingTokens.md)
     }
 
     var body: some View {
-            VStack(spacing: 20) {
+            VStack(spacing: SpacingTokens.md) {
             Text("Start Hard Focus")
                 .font(TypographyTokens.displaySmall)
                 .padding(.top, 20)
@@ -879,7 +870,6 @@ struct DeepFocusSetupSheet: View {
                     Text("Infinite").tag(false)
                 }
                 .pickerStyle(.segmented)
-                .padding(.horizontal, 20)
 
                 if isTimedMode {
                     VStack(spacing: 16) {
@@ -923,7 +913,7 @@ struct DeepFocusSetupSheet: View {
                             .foregroundStyle(minutes < 480 ? tokens.textPrimary : tokens.textTertiary)
                         }
                         .padding(.vertical, 12)
-                        .padding(.horizontal, 20)
+                        .padding(.horizontal, SpacingTokens.md)
                         .background(tokens.bgFloating.opacity(0.5), in: RoundedRectangle(cornerRadius: 12))
                         .overlay(
                             RoundedRectangle(cornerRadius: 12)
@@ -961,17 +951,17 @@ struct DeepFocusSetupSheet: View {
                             }
                         }
                     }
-                    .padding(.horizontal, 20)
                     .transition(.opacity.combined(with: .move(edge: .top)))
                 } else {
                     Text("Session runs until you manually end it")
                         .font(TypographyTokens.caption)
                         .foregroundStyle(tokens.textSecondary)
-                        .padding(.horizontal, 20)
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }
             .animation(.easeInOut(duration: 0.2), value: isTimedMode)
+            .sectionCard()
+            .padding(.horizontal, SpacingTokens.md)
 
             templateSection
 
@@ -981,7 +971,6 @@ struct DeepFocusSetupSheet: View {
                     .textCase(.uppercase)
                     .tracking(1.5)
                     .foregroundStyle(tokens.textTertiary)
-                    .padding(.horizontal, 20)
 
                 ScrollView {
                     VStack(alignment: .leading, spacing: 2) {
@@ -1028,13 +1017,9 @@ struct DeepFocusSetupSheet: View {
                     .padding(.vertical, SpacingTokens.xs)
                 }
                 .frame(maxHeight: 280)
-                .background(tokens.bgFloating.opacity(0.35), in: RoundedRectangle(cornerRadius: RadiusTokens.md))
-                .overlay {
-                    RoundedRectangle(cornerRadius: RadiusTokens.md)
-                        .stroke(tokens.sectionBorder.opacity(0.3), lineWidth: 0.5)
-                }
-                .padding(.horizontal, 20)
             }
+            .sectionCard()
+            .padding(.horizontal, SpacingTokens.md)
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Unlock Passphrase")
@@ -1066,7 +1051,8 @@ struct DeepFocusSetupSheet: View {
                     .shadow(color: isPassphraseFocused ? tokens.accentTerracotta.opacity(0.08) : .clear, radius: 8, y: 1)
                     .animation(MotionTokens.focusEase, value: isPassphraseFocused)
             }
-            .padding(.horizontal, 20)
+            .sectionCard()
+            .padding(.horizontal, SpacingTokens.md)
 
             HStack(spacing: SpacingTokens.md) {
                 Button("Cancel") {
@@ -1098,7 +1084,7 @@ struct DeepFocusSetupSheet: View {
                 }
                 .buttonStyle(.plain)
             }
-            .padding(.horizontal, 20)
+            .padding(.horizontal, SpacingTokens.md)
             .padding(.bottom, 20)
         }
         .frame(width: 300)

--- a/macos/TodoFocusMac/TodoFocusMac.xcodeproj/project.pbxproj
+++ b/macos/TodoFocusMac/TodoFocusMac.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		CCD83328C673F343DC524362 /* TodoRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA83C04DBE6BA2D4990E7C67 /* TodoRowView.swift */; };
 		CD78286DADAFB794C7933580 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = CE5F3BDE707034517F4204D9 /* GRDB */; };
 		CE68D70D52B8AC25F5488A5A /* AppGroupDatabasePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E58F663C2760243A4C31F1 /* AppGroupDatabasePath.swift */; };
+		CF2955A202B58FC057AA11B0 /* SectionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36F9256104B1AA7CE934BA8 /* SectionCard.swift */; };
 		D2DE83D790E60752968ACD55 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3F7C7F2B40002DD63B8FFBD4 /* Assets.xcassets */; };
 		D2F5C48FDC857B3D6D2B6E36 /* ImmersiveHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CECDF3CE43A5D8655A27316 /* ImmersiveHeaderView.swift */; };
 		D47CCAA280BB56FC203BAE6E /* ExportModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1A2C850F597AAD8E6B8A1F /* ExportModels.swift */; };
@@ -301,6 +302,7 @@
 		BC092BBEC0446A8B33FF3E7A /* QuickAddNaturalLanguageParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAddNaturalLanguageParser.swift; sourceTree = "<group>"; };
 		BE07B39987D458DF0BF2B7D5 /* LaunchResourceEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchResourceEditorView.swift; sourceTree = "<group>"; };
 		C041E259E1AA3D6238B2A360 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
+		C36F9256104B1AA7CE934BA8 /* SectionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionCard.swift; sourceTree = "<group>"; };
 		C4C02F3CCE23A226FC531579 /* HardFocusSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardFocusSessionManager.swift; sourceTree = "<group>"; };
 		C714727C5D2521DFF716DC5F /* TodoFocusMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoFocusMacApp.swift; sourceTree = "<group>"; };
 		CD2CD5B74E5D46555A530C5A /* DeepFocusTemplateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepFocusTemplateStoreTests.swift; sourceTree = "<group>"; };
@@ -570,6 +572,7 @@
 				69D7E8E5ABB00A1C6EC8B171 /* InteractiveStyles.swift */,
 				557C0A5FAD5A80348079DDAA /* MotionTokens.swift */,
 				085B1E712E2F332EBC0416BB /* ResizableSplitView.swift */,
+				C36F9256104B1AA7CE934BA8 /* SectionCard.swift */,
 				E7D83311569889B9E7535C52 /* ShadowTokens.swift */,
 				2B5633165F8175CAD2AB7A90 /* ShortcutHintBar.swift */,
 				18071042FF2C42C110635591 /* SpacingTokens.swift */,
@@ -974,6 +977,7 @@
 				460E2FF0EC5F13E47EC00164 /* QuickCaptureView.swift in Sources */,
 				49C094D18BEB5BD380E70B5B /* ResizableSplitView.swift in Sources */,
 				98FEBD78B7C911D8AD057405 /* RootView.swift in Sources */,
+				CF2955A202B58FC057AA11B0 /* SectionCard.swift in Sources */,
 				A07A6F7772AE2B855A31DB11 /* SelectionState.swift in Sources */,
 				EF6BCA8F5969CF778AB4177C /* SettingsView.swift in Sources */,
 				5F12FCAFDB342F98CCC3D98F /* ShadowTokens.swift in Sources */,


### PR DESCRIPTION
## Summary
- New reusable `.sectionCard()` modifier (`Sources/Features/Common/SectionCard.swift`) — `bgSubtle` fill, full `sectionBorder` stroke, `RadiusTokens.lg`, `SpacingTokens.lg` inset, `shadowMedium`.
- `DeepFocusSetupSheet` — Focus Mode, Templates, Blocked Apps, and Unlock Passphrase each wrap in `.sectionCard()` so the modal reads as a stack of distinct atomic blocks. Tightened outer card margin (20pt → `SpacingTokens.md`) and removed the now-redundant inner background/border around the Blocked Apps ScrollView.
- `TaskDetailView` — folded `dateSection(todo:)` into the `header(todo:)` view, so title, Deep Focus pill, close X, and the Schedule chip share one elevated zone. Removed `dateSection` from its sibling slot in the ScrollView to avoid duplication.
- Removed the title's input-style fill/stroke from the Deep Focus + close-X button group so the buttons no longer light up with an orange focus border when the title field is focused.

## Test plan
- [ ] `xcodegen generate` then `xcodebuild build -project "macos/TodoFocusMac/TodoFocusMac.xcodeproj" -scheme "TodoFocusMac" -destination "platform=macOS"` succeeds
- [ ] `xcodebuild test ...` passes (53/53 locally)
- [ ] Open a task: title, Deep Focus pill, close X, and the Today/Schedule chip render in one elevated header zone with the gradient drop-shadow sitting below the Schedule chip
- [ ] Focus the title field — only the title's focus ring lights up; the Deep Focus button group stays neutral
- [ ] ⌘⇧F opens the modal with Focus Mode, Templates, Blocked Apps, and Unlock Passphrase each rendered as a distinct card
- [ ] Blocked Apps still scrolls within ~280pt; templates scroll horizontally; passphrase focus glow still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)